### PR TITLE
Fixed escoria.current_state when dialog line finishes

### DIFF
--- a/addons/escoria-core/game/core-scripts/behaviors/esc_movable.gd
+++ b/addons/escoria-core/game/core-scripts/behaviors/esc_movable.gd
@@ -54,7 +54,8 @@ onready var task = MovableTask.NONE
 # Add the signal "arrived" to the parent node, which is emitted when
 # the destination position was reached
 func _ready() -> void:
-	parent.add_user_signal("arrived")
+	if not parent.has_user_signal("arrived"):
+		parent.add_user_signal("arrived")
 	
 
 # Main processing loop

--- a/addons/escoria-core/game/core-scripts/esc/commands/say.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/say.gd
@@ -78,4 +78,5 @@ func run(command_params: Array) -> int:
 		command_params[1]
 	)
 	yield(escoria.dialog_player, "dialog_line_finished")
+	escoria.current_state = escoria.GAME_STATE.DEFAULT
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -158,9 +158,12 @@ func _ready():
 	
 	_detect_children()
 	
-	connect("mouse_entered", self, "_on_mouse_entered")
-	connect("mouse_exited", self, "_on_mouse_exited")
-	connect("input_event", self, "manage_input")
+	if not self.is_connected("mouse_entered", self, "_on_mouse_entered"):
+		connect("mouse_entered", self, "_on_mouse_entered")
+	if not self.is_connected("mouse_exited", self, "_on_mouse_exited"):
+		connect("mouse_exited", self, "_on_mouse_exited")
+	if not self.is_connected("input_event", self, "manage_input"):
+		connect("input_event", self, "manage_input")
 	
 	# Register and connect all elements to Escoria backoffice.
 	if not Engine.is_editor_hint():
@@ -170,7 +173,16 @@ func _ready():
 
 			add_child(_movable)
 	
-		escoria.event_manager.connect("event_finished", self, "_update_terrain")
+		if not escoria.event_manager.is_connected(
+			"event_finished",
+			self, 
+			"_update_terrain"
+		):
+			escoria.event_manager.connect(
+				"event_finished", 
+				self, 
+				"_update_terrain"
+			)
 		
 		escoria.object_manager.register_object(
 			ESCObject.new(
@@ -183,16 +195,65 @@ func _ready():
 		terrain = escoria.room_terrain
 		
 		if !is_trigger:
-			connect("mouse_entered_item", escoria.inputs_manager, "_on_mouse_entered_item")
-			connect("mouse_exited_item", escoria.inputs_manager, "_on_mouse_exited_item")
-			connect("mouse_left_clicked_item", escoria.inputs_manager, "_on_mouse_left_clicked_item")
-			connect("mouse_double_left_clicked_item", escoria.inputs_manager, "_on_mouse_left_double_clicked_item")
-			connect("mouse_right_clicked_item", escoria.inputs_manager, "_on_mouse_right_clicked_item")
+			if not self.is_connected(
+				"mouse_entered_item", 
+				escoria.inputs_manager, 
+				"_on_mouse_entered_item"
+			):
+				connect(
+					"mouse_entered_item", 
+					escoria.inputs_manager, 
+					"_on_mouse_entered_item"
+				)
+			if not self.is_connected(
+				"mouse_exited_item", 
+				escoria.inputs_manager, 
+				"_on_mouse_exited_item"
+			):
+				connect(
+					"mouse_exited_item", 
+					escoria.inputs_manager, 
+					"_on_mouse_exited_item"
+				)
+			if not self.is_connected(
+				"mouse_left_clicked_item", 
+				escoria.inputs_manager, 
+				"_on_mouse_left_clicked_item"
+			):
+				connect(
+					"mouse_left_clicked_item", 
+					escoria.inputs_manager, 
+					"_on_mouse_left_clicked_item"
+				)
+			if not self.is_connected(
+				"mouse_double_left_clicked_item", 
+				escoria.inputs_manager, 
+				"_on_mouse_left_double_clicked_item"
+			):
+				connect(
+					"mouse_double_left_clicked_item", 
+					escoria.inputs_manager, 
+					"_on_mouse_left_double_clicked_item"
+				)
+			if not self.is_connected(
+				"mouse_right_clicked_item", 
+				escoria.inputs_manager, 
+				"_on_mouse_right_clicked_item"
+			):
+				connect(
+					"mouse_right_clicked_item", 
+					escoria.inputs_manager, 
+					"_on_mouse_right_clicked_item"
+				)
 		else:
-			connect("area_entered", self, "element_entered")
-			connect("area_exited", self, "element_exited")
-			connect("body_entered", self, "element_entered")
-			connect("body_exited", self, "element_exited")
+			if not self.is_connected("area_entered", self, "element_entered"):
+				connect("area_entered", self, "element_entered")
+			if not self.is_connected("area_exited", self, "element_exited"):
+				connect("area_exited", self, "element_exited")
+			if not self.is_connected("body_entered", self, "element_entered"):
+				connect("body_entered", self, "element_entered")
+			if not self.is_connected("body_exited", self, "element_exited"):
+				connect("body_exited", self, "element_exited")
 		
 	# If object can be in the inventory, set default_action_inventory to same as
 	# default_action, if default_action_inventory is not set

--- a/game/rooms/room10/esc/button_accept_input_test.esc
+++ b/game/rooms/room10/esc/button_accept_input_test.esc
@@ -2,10 +2,12 @@
 
 :use
 say player "Hello. I will now walk a bit and won't listen at what you say!"
+#wait 1
 accept_input NONE
 walk_block player player_start
 walk_block player accept_input_location
 say player "Ha! Now you can't even skip this text!" dialog_box_inset
 accept_input SKIP
-say player "Okay, you can skip this text, but still not move me."
+say player "Okay, you can skip this text, but still not move me until 3 seconds have passed."
+wait 3
 accept_input ALL


### PR DESCRIPTION
This was causing ESC execution to hang after a say command because the state was at DIALOG and was not changed after the line is said.

- Also fixed connect() errors concerning the player being ready'd 2 times in certain cases, so trying to connect signals twice. That is a lot of checks!