### PR TITLE
Move settings load and main menu loading in _init method

### DIFF
--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -105,21 +105,35 @@ func _init():
 	self.save_manager = ESCSaveManager.new()
 	self.inputs_manager = ESCInputsManager.new()
 	self.controller = ESCController.new()
-	self.game_scene = resource_cache.get_resource(
-		ProjectSettings.get_setting("escoria/ui/game_scene")
-	).instance()
 	
+	settings = ESCSaveSettings.new()
+	settings = save_manager.load_settings()
+	_on_settings_loaded(settings)
+	
+	if ProjectSettings.get_setting("escoria/ui/game_scene") == "":
+		logger.report_errors("escoria.gd", 
+			["Parameter escoria/ui/game_scene is not set!"]
+		)
+	else:
+		self.game_scene = resource_cache.get_resource(
+			ProjectSettings.get_setting("escoria/ui/game_scene")
+		).instance()
+		
+	if ProjectSettings.get_setting("escoria/ui/main_menu_scene") == "":
+		logger.report_errors("escoria.gd", 
+			["Parameter escoria/ui/main_menu_scene is not set!"]
+		)
+	else:
+		self.main_menu_instance = resource_cache.get_resource(
+			ProjectSettings.get_setting("escoria/ui/main_menu_scene")
+		).instance()
 
 
 # Load settings
 func _ready():
 	inputs_manager.register_core()
-	settings = ESCSaveSettings.new()
-	settings = save_manager.load_settings()
-	escoria._on_settings_loaded(escoria.settings)
-	self.main_menu_instance = resource_cache.get_resource(
-			ProjectSettings.get_setting("escoria/ui/main_menu_scene")
-		).instance()
+	
+	
 
 # Called by Main menu "start new game"
 func new_game():
@@ -259,7 +273,7 @@ func do(action: String, params: Array = [], can_interrupt: bool = false) -> void
 #
 # * p_settings: Loaded settings
 func _on_settings_loaded(p_settings: ESCSaveSettings) -> void:
-	escoria.logger.info("******* settings loaded")
+	logger.info("******* settings loaded")
 	if p_settings != null:
 		settings = p_settings
 	else:

--- a/addons/escoria-core/game/main_scene.gd
+++ b/addons/escoria-core/game/main_scene.gd
@@ -6,9 +6,14 @@ extends Node
 # Start the main menu
 func _ready():
 	if escoria.main_menu_instance == null:
-		escoria.main_menu_instance = escoria.resource_cache.get_resource(
-			ProjectSettings.get_setting("escoria/ui/main_menu_scene")
-		).instance()
+		if ProjectSettings.get_setting("escoria/ui/main_menu_scene") == "":
+			escoria.logger.report_errors("escoria.gd", 
+				["Parameter escoria/ui/main_menu_scene is not set!"]
+			)
+		else:
+			escoria.main_menu_instance = escoria.resource_cache.get_resource(
+				ProjectSettings.get_setting("escoria/ui/main_menu_scene")
+			).instance()
 	escoria.call_deferred("add_child", escoria.main_menu_instance)
 	
 	


### PR DESCRIPTION
I managed to put all scenes loadings in escoria.gd into _init() method. 
I also added a few checks so that a message is displayed when some mandatory Escoria Settings are not set.