### PR TITLE
Removed hardcoded "camera" name reference and manual tween node camera

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_push.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_push.gd
@@ -35,7 +35,7 @@ func validate(arguments: Array):
 
 # Run the command
 func run(command_params: Array) -> int:
-	(escoria.object_manager.get_object("camera").node as ESCCamera)\
+	(escoria.object_manager.get_object("_camera").node as ESCCamera)\
 		.push(
 			escoria.object_manager.get_object(command_params[0]).node,
 			command_params[1],

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_pos.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_pos.gd
@@ -20,7 +20,7 @@ func configure() -> ESCCommandArgumentDescriptor:
 
 # Run the command
 func run(command_params: Array) -> int:
-	(escoria.object_manager.get_object("camera").node as ESCCamera)\
+	(escoria.object_manager.get_object("_camera").node as ESCCamera)\
 			.set_target(
 				Vector2(command_params[1], command_params[2]), 
 				command_params[0]

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_target.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_target.gd
@@ -34,7 +34,7 @@ func validate(arguments: Array):
 
 # Run the command
 func run(command_params: Array) -> int:
-	(escoria.object_manager.get_object("camera").node as ESCCamera)\
+	(escoria.object_manager.get_object("_camera").node as ESCCamera)\
 		.set_target(
 			escoria.object_manager.get_object(command_params[1]).node,
 			command_params[0]

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom.gd
@@ -21,7 +21,7 @@ func configure() -> ESCCommandArgumentDescriptor:
 
 # Run the command
 func run(command_params: Array) -> int:
-	(escoria.object_manager.get_object("camera").node as ESCCamera)\
+	(escoria.object_manager.get_object("_camera").node as ESCCamera)\
 		.set_camera_zoom(
 			command_params[0],
 			command_params[1]

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom_height.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom_height.gd
@@ -34,7 +34,7 @@ func validate(arguments: Array):
 
 # Run the command
 func run(command_params: Array) -> int:
-	(escoria.object_manager.get_object("camera").node as ESCCamera)\
+	(escoria.object_manager.get_object("_camera").node as ESCCamera)\
 		.set_camera_zoom(
 			command_params[0] / escoria.game_size.y,
 			command_params[1]

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_shift.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_shift.gd
@@ -20,7 +20,7 @@ func configure() -> ESCCommandArgumentDescriptor:
 
 # Run the command
 func run(command_params: Array) -> int:
-	(escoria.object_manager.get_object("camera").node as ESCCamera)\
+	(escoria.object_manager.get_object("_camera").node as ESCCamera)\
 		.shift(
 			command_params[0],
 			command_params[1],

--- a/addons/escoria-core/game/core-scripts/esc/esc_object_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_object_manager.gd
@@ -6,7 +6,8 @@ class_name ESCObjectManager
 const RESERVED_OBJECTS = [
 	"_music",
 	"_sound",
-	"_speech"
+	"_speech",
+	"_camera"
 ]
 
 

--- a/addons/escoria-core/game/core-scripts/esc_room.gd
+++ b/addons/escoria-core/game/core-scripts/esc_room.gd
@@ -78,7 +78,7 @@ func _ready():
 			),
 			true
 		)
-		game.get_node("camera").set_target(player)
+		escoria.object_manager.get_object("_camera").node.set_target(player)
 	
 	for n in get_children():
 		if n is ESCLocation and n.is_start_location:

--- a/addons/escoria-core/game/main.gd
+++ b/addons/escoria-core/game/main.gd
@@ -117,7 +117,7 @@ func set_camera_limits(camera_limit_id: int = 0) -> void:
 			[scene_camera_limits]
 		)
 
-	current_scene.game.get_node("camera").set_limits(limits)
+	escoria.object_manager.get_object("_camera").node.set_limits(limits)
 
 
 func save_game(p_savegame_res: Resource) -> void:

--- a/addons/escoria-core/game/scenes/camera_player/camera.tscn
+++ b/addons/escoria-core/game/scenes/camera_player/camera.tscn
@@ -7,5 +7,3 @@ current = true
 drag_margin_h_enabled = true
 drag_margin_v_enabled = true
 script = ExtResource( 1 )
-
-[node name="tween" type="Tween" parent="."]

--- a/addons/escoria-core/game/scenes/camera_player/esc_camera.gd
+++ b/addons/escoria-core/game/scenes/camera_player/esc_camera.gd
@@ -4,7 +4,7 @@ class_name ESCCamera
 
 
 # Reference to the tween node for animating camera movements
-onready var tween = $"tween"
+var tween
 
 # Target position of the camera
 var target: Vector2 = Vector2()
@@ -15,6 +15,7 @@ var follow_target: Node = null
 # Target zoom of the camera
 var zoom_target: Vector2
 
+# Time of zoom
 var zoom_time
 
 
@@ -198,10 +199,12 @@ func _process(_delta):
 		self.global_position = follow_target.global_position
 
 func _ready():
+	tween = Tween.new()
+	add_child(tween)
 	tween.connect("tween_all_completed", self, "target_reached")
 	escoria.object_manager.register_object(
 		ESCObject.new(
-			self.name,
+			"_camera",
 			self
 		),
 		true

--- a/addons/escoria-ui-9verbs/game.gd
+++ b/addons/escoria-ui-9verbs/game.gd
@@ -176,14 +176,14 @@ func _on_event_done(_event_name: String):
 func pause_game():
 	if pause_menu.visible:
 		pause_menu.hide()
-		escoria.main.current_scene.game.get_node("camera").current = true
+		escoria.object_manager.get_object("_camera").node.current = true
 		escoria.main.current_scene.game.show_ui()
 		escoria.main.current_scene.show()
 		escoria.set_game_paused(false)
 	else:
 		pause_menu.set_save_enabled(escoria.save_manager.save_enabled)
 		pause_menu.show()
-		escoria.main.current_scene.game.get_node("camera").current = false
+		escoria.object_manager.get_object("_camera").node.current = false
 		escoria.main.current_scene.game.hide_ui()
 		escoria.main.current_scene.hide()
 		escoria.set_game_paused(true)

--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -156,7 +156,7 @@ func _on_event_done(event_name: String):
 func pause_game():
 	if $CanvasLayer/pause_menu.visible:
 		$CanvasLayer/pause_menu.hide()
-		escoria.main.current_scene.game.get_node("camera").current = true
+		escoria.object_manager.get_object("_camera").node.current = true
 		escoria.main.current_scene.game.show_ui()
 		escoria.main.current_scene.show()
 	else:
@@ -164,7 +164,7 @@ func pause_game():
 			escoria.save_manager.save_enabled
 		)
 		$CanvasLayer/pause_menu.show()
-		escoria.main.current_scene.game.get_node("camera").current = false
+		escoria.object_manager.get_object("_camera").node.current = false
 		escoria.main.current_scene.game.hide_ui()
 		escoria.main.current_scene.hide()
 

--- a/docs/api/ESCCamera.md
+++ b/docs/api/ESCCamera.md
@@ -48,6 +48,8 @@ Target zoom of the camera
 var zoom_time
 ```
 
+Time of zoom
+
 ### zoom\_transform
 
 ```gdscript

--- a/docs/api/ESCObjectManager.md
+++ b/docs/api/ESCObjectManager.md
@@ -13,7 +13,7 @@ A manager for ESC objects
 ### RESERVED\_OBJECTS
 
 ```gdscript
-const RESERVED_OBJECTS: Array = ["_music","_sound","_speech"]
+const RESERVED_OBJECTS: Array = ["_music","_sound","_speech","_camera"]
 ```
 
 ## Property Descriptions

--- a/project.godot
+++ b/project.godot
@@ -648,8 +648,6 @@ debug/terminate_on_errors=true
 debug/development_lang="en"
 ui/tooltip_follows_mouse=true
 ui/default_dialog_scene="res://game/ui/commons/dialogs/dialog_label.tscn"
-ui/main_menu_scene="res://game/ui/commons/main_menu/main_menu.tscn"
-ui/pause_menu_scene="res://game/ui/commons/pause_menu/pause_menu.tscn"
 main/text_lang="fr_FR"
 main/voice_lang="fr_FR"
 sound/music_volume=1
@@ -672,6 +670,8 @@ sound/speech_folder="res://game/speech"
 sound/speech_extension="ogg"
 ui/default_transition="curtain"
 ui/transition_paths=[ "res://addons/escoria-core/game/scenes/transitions/shaders/" ]
+ui/main_menu_scene="res://game/ui/commons/main_menu/main_menu.tscn"
+ui/pause_menu_scene="res://game/ui/commons/pause_menu/pause_menu.tscn"
 internals/save_data=""
 
 [input]


### PR DESCRIPTION
Fixes #409 