### PR TITLE
Move Escoria settings load action out of init

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Escoria Rewrite
+# Escoria
+
+![Escoria Logo](https://raw.githubusercontent.com/godot-escoria/escoria-demo-game/main/addons/escoria-core/design/escoria-logo-small.png)
 
 Libre framework for the creation of point-and-click adventure games with the MIT-licensed multi-platform game engine [Godot Engine](https://godotengine.org).
 
@@ -36,9 +38,17 @@ In alphabetical order:
 * [ESC language documentation](docs/esc.md)
 * [API reference](docs/api)
 
+## Issues & support
+
+Escoria's development is organized using Github issues. 
+If you encounter an issue, a bug or a question to developers, please submit a ticket in our [issues page](https://github.com/godot-escoria/escoria-issues/issues). 
+You can also find support on our official Discord server.
+
+[![Join our Discord](https://img.shields.io/discord/884336424780984330.svg?label=Join%20our%20Discord&logo=Discord&colorB=7289da&style=for-the-badge)](https://discord.com/invite/jMxJjuBY5Z)
+
 ## Roadmap
 
-Escoria's development is organized using Github [issues](https://github.com/godotengine/escoria/issues). Take a look, what's planned for the next version.
+Take a look, what's planned for the next version in our [projects boards](https://github.com/godot-escoria/escoria-demo-game/projects).
 
 ## Licensing
 

--- a/addons/escoria-core/game/core-scripts/esc_background.gd
+++ b/addons/escoria-core/game/core-scripts/esc_background.gd
@@ -85,7 +85,8 @@ func _ready():
 func _input(event) -> void:
 	if not escoria.current_state == escoria.GAME_STATE.DEFAULT:
 		return
-	if event.is_action_pressed("switch_action_verb"):
+	if InputMap.has_action("switch_action_verb") \
+			and event.is_action_pressed("switch_action_verb"):
 		if event.button_index == BUTTON_WHEEL_UP:
 			emit_signal("mouse_wheel_up")
 		elif event.button_index == BUTTON_WHEEL_DOWN:

--- a/addons/escoria-core/game/core-scripts/esc_inventory_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_inventory_item.gd
@@ -54,7 +54,8 @@ func _ready():
 #
 # - event: The event received
 func _on_inventory_item_gui_input(event: InputEvent):
-	if event.is_action_pressed("switch_action_verb"):
+	if InputMap.has_action("switch_action_verb") \
+			and event.is_action_pressed("switch_action_verb"):
 		if event.button_index == BUTTON_WHEEL_UP:
 			escoria.inputs_manager._on_mousewheel_action(-1)
 		elif event.button_index == BUTTON_WHEEL_DOWN:

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -108,8 +108,6 @@ func _init():
 	self.controller = ESCController.new()
 	
 	settings = ESCSaveSettings.new()
-	settings = save_manager.load_settings()
-	_on_settings_loaded(settings)
 	
 	if ProjectSettings.get_setting("escoria/ui/game_scene") == "":
 		logger.report_errors("escoria.gd", 
@@ -123,7 +121,14 @@ func _init():
 
 # Load settings
 func _ready():
+	settings = save_manager.load_settings()
+	_on_settings_loaded(settings)
 	inputs_manager.register_core()
+	if ProjectSettings.get_setting("escoria/main/game_start_script").empty():
+		logger.report_errors("escoria.gd", 
+		[
+			"Project setting 'escoria/main/game_start_script' is not set!"
+		])
 	start_script = self.esc_compiler.load_esc_file(
 		ProjectSettings.get_setting("escoria/main/game_start_script")
 	)

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -293,7 +293,8 @@ func _on_settings_loaded(p_settings: ESCSaveSettings) -> void:
 
 # Input function to manage specific input keys
 func _input(event):
-	if event.is_action_pressed("esc_show_debug_prompt"):
+	if InputMap.has_action("esc_show_debug_prompt") \
+			and event.is_action_pressed("esc_show_debug_prompt"):
 		escoria.main.get_node("layers/debug_layer/esc_prompt_popup").popup()
 	
 	if event.is_action_pressed("ui_cancel"):

--- a/addons/escoria-core/plugin.gd
+++ b/addons/escoria-core/plugin.gd
@@ -12,6 +12,10 @@ const autoloads = {
 func _enter_tree():
 	for key in autoloads.keys():
 		add_autoload_singleton(key, autoloads[key])
+		
+	# Add input actions in InputMap
+	InputMap.add_action("switch_action_verb")
+	InputMap.add_action("esc_show_debug_prompt")
 	
 	# Prepare settings
 	set_escoria_main_settings()
@@ -290,5 +294,8 @@ func _exit_tree():
 	for key in autoloads.keys():
 		if ProjectSettings.has_setting(key):
 			remove_autoload_singleton(key)
+	
+	InputMap.erase_action("switch_action_verb")
+	InputMap.erase_action("esc_show_debug_prompt")
 	
 	

--- a/docs/api/ESCLogger.md
+++ b/docs/api/ESCLogger.md
@@ -13,7 +13,7 @@ Logging framework for Escoria
 ### LOG\_DEBUG
 
 ```gdscript
-const LOG_WARNING: int = 1
+const LOG_INFO: int = 2
 ```
 
 Valid log levels
@@ -21,7 +21,7 @@ Valid log levels
 ### LOG\_ERROR
 
 ```gdscript
-const LOG_WARNING: int = 1
+const LOG_INFO: int = 2
 ```
 
 Valid log levels
@@ -29,7 +29,7 @@ Valid log levels
 ### LOG\_INFO
 
 ```gdscript
-const LOG_WARNING: int = 1
+const LOG_INFO: int = 2
 ```
 
 Valid log levels
@@ -37,7 +37,7 @@ Valid log levels
 ### LOG\_WARNING
 
 ```gdscript
-const LOG_WARNING: int = 1
+const LOG_INFO: int = 2
 ```
 
 Valid log levels

--- a/docs/api/ESCLogger.md
+++ b/docs/api/ESCLogger.md
@@ -13,7 +13,7 @@ Logging framework for Escoria
 ### LOG\_DEBUG
 
 ```gdscript
-const LOG_INFO: int = 2
+const LOG_ERROR: int = 0
 ```
 
 Valid log levels
@@ -21,7 +21,7 @@ Valid log levels
 ### LOG\_ERROR
 
 ```gdscript
-const LOG_INFO: int = 2
+const LOG_ERROR: int = 0
 ```
 
 Valid log levels
@@ -29,7 +29,7 @@ Valid log levels
 ### LOG\_INFO
 
 ```gdscript
-const LOG_INFO: int = 2
+const LOG_ERROR: int = 0
 ```
 
 Valid log levels
@@ -37,7 +37,7 @@ Valid log levels
 ### LOG\_WARNING
 
 ```gdscript
-const LOG_INFO: int = 2
+const LOG_ERROR: int = 0
 ```
 
 Valid log levels


### PR DESCRIPTION
Fixes potential crash caused by escoria being null if load_settings() fails when it tries to log the error.