### PR TITLE
Added a check on unknown ESC command at compilation time

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_compiler.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_compiler.gd
@@ -219,8 +219,9 @@ func _compile(lines: Array) -> Array:
 			returned.append(dialog_option)
 		elif command_regex.search(line):
 			var command = ESCCommand.new(line)
-			escoria.logger.trace("Line is the command %s" % command.name)
-			returned.append(command)
+			if command.is_valid():
+				escoria.logger.trace("Line is the command %s" % command.name)
+				returned.append(command)
 		else:
 			escoria.logger.report_errors(
 				"Invalid ESC line detected",


### PR DESCRIPTION
If an unknown command is detected on compile ESC, fail.
This was not triggering any error in ESCRoom because ESCRoom looks for `:setup` and `:ready` events only. Any other element would not be considered.