### PR TITLE
fix: Resets the current verb after the action has finished

### DIFF
--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -204,6 +204,7 @@ func pause_game():
 
 func _on_action_finished():
 	$mouse_layer/verbs_menu.clear_tool_texture()
+	$mouse_layer/verbs_menu.iterate_actions_cursor(0)
 
 
 func _on_MenuButton_pressed() -> void:


### PR DESCRIPTION
Simplemouse only sets the verb if it is changed and thus it is set to nothing when an action finished and resets the verb