### PR TITLE
Re-add removed assert(false)

### DIFF
--- a/addons/escoria-core/game/core-scripts/log/esc_logger.gd
+++ b/addons/escoria-core/game/core-scripts/log/esc_logger.gd
@@ -120,7 +120,8 @@ func warning(string: String, args = []):
 			escoria.main.current_scene.game.show_crash_popup(
 				[log_file.get_path_absolute()]
 			)
-
+			assert(false)
+			
 
 # Log an error message
 #
@@ -154,6 +155,7 @@ func error(string: String, args = [], do_savegame: bool = true):
 			_log(message, true)
 			
 			escoria.main.current_scene.game.show_crash_popup(files_to_send)
+			assert(false)
 
 
 # Log a warning message about an ESC file


### PR DESCRIPTION
Asserts were removed so the game would not stop to debugger.

Note: asserts are not processed in release mode so the game will not hang in other modes than debug.