### PR TITLE
Adds default crash popup, if game.gd doesn't reimplement it

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_game.gd
+++ b/addons/escoria-core/game/core-scripts/esc_game.gd
@@ -310,5 +310,25 @@ func hide_main_menu():
 
 
 # Shows the crash popup when a crash occurs
-func show_crash_popup() -> void:
-	pass
+#
+# #### Parameters
+#
+# - files: Array of strings containing the paths to the files generated on crash
+func show_crash_popup(files: Array = []) -> void:
+	connect("crash_popup_confirmed", escoria, "quit", 
+		[], CONNECT_ONESHOT)
+	var crash_popup = AcceptDialog.new()
+	crash_popup.popup_exclusive = true
+	crash_popup.pause_mode = Node.PAUSE_MODE_PROCESS
+	add_child(crash_popup)
+	var files_to_send: String = ""
+	for file in files:
+		files_to_send += "- %s\n" % file
+	crash_popup.dialog_text = tr(ProjectSettings.get_setting(
+		"escoria/debug/crash_message")
+	) % files_to_send
+	crash_popup.popup_centered()
+	escoria.set_game_paused(true)
+	yield(crash_popup, "confirmed")
+	emit_signal("crash_popup_confirmed")
+

--- a/addons/escoria-core/game/core-scripts/log/esc_logger.gd
+++ b/addons/escoria-core/game/core-scripts/log/esc_logger.gd
@@ -116,7 +116,7 @@ func warning(string: String, args = []):
 			) % files 
 			
 			_log(message, true)
-			
+			escoria.set_game_paused(true)
 			escoria.main.current_scene.game.show_crash_popup(
 				[log_file.get_path_absolute()]
 			)
@@ -153,7 +153,7 @@ func error(string: String, args = [], do_savegame: bool = true):
 			) % files 
 			
 			_log(message, true)
-			
+			escoria.set_game_paused(true)
 			escoria.main.current_scene.game.show_crash_popup(files_to_send)
 			assert(false)
 

--- a/addons/escoria-core/game/main.gd
+++ b/addons/escoria-core/game/main.gd
@@ -161,4 +161,3 @@ func check_game_scene_methods():
 	assert(current_scene.game.has_method("show_ui"))
 	assert(current_scene.game.has_method("_on_event_done"))
 	
-	assert(current_scene.game.has_method("show_crash_popup"))

--- a/addons/escoria-ui-9verbs/game.gd
+++ b/addons/escoria-ui-9verbs/game.gd
@@ -233,22 +233,3 @@ func _on_MenuButton_pressed() -> void:
 	
 func _on_action_finished() -> void:
 	verbs_menu.unselect_actions()
-
-
-func show_crash_popup(files = []) -> void:
-	connect("crash_popup_confirmed", escoria, "quit", 
-		[], CONNECT_ONESHOT)
-	var crash_popup = AcceptDialog.new()
-	crash_popup.popup_exclusive = true
-	crash_popup.pause_mode = Node.PAUSE_MODE_PROCESS
-	add_child(crash_popup)
-	var files_to_send: String = ""
-	for file in files:
-		files_to_send += "- %s\n" % file
-	crash_popup.dialog_text = tr(ProjectSettings.get_setting(
-		"escoria/debug/crash_message")
-	) % files_to_send
-	crash_popup.popup_centered()
-	escoria.set_game_paused(true)
-	yield(crash_popup, "confirmed")
-	emit_signal("crash_popup_confirmed")

--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -209,22 +209,3 @@ func _on_action_finished():
 
 func _on_MenuButton_pressed() -> void:
 	pause_game()
-
-
-func show_crash_popup(files = []) -> void:
-	connect("crash_popup_confirmed", escoria, "quit", 
-		[], CONNECT_ONESHOT)
-	var crash_popup = AcceptDialog.new()
-	crash_popup.popup_exclusive = true
-	crash_popup.pause_mode = Node.PAUSE_MODE_PROCESS
-	add_child(crash_popup)
-	var files_to_send: String = ""
-	for file in files:
-		files_to_send += "- %s\n" % file
-	crash_popup.dialog_text = tr(ProjectSettings.get_setting(
-		"escoria/debug/crash_message")
-	) % files_to_send
-	crash_popup.popup_centered()
-	escoria.set_game_paused(true)
-	yield(crash_popup, "confirmed")
-	emit_signal("crash_popup_confirmed")


### PR DESCRIPTION
Also overriding the show_crash_popup() function is not mandatory