### PR TITLE
Reverted setting ESC_LAST_SCENE too early in ESCRoom

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
@@ -84,10 +84,10 @@ func run(command_params: Array) -> int:
 			"Awaiting transition %s (out) to be finished." % str(transition_id)
 		)
 		yield(escoria.main.scene_transition, "transition_done")
-		
-	# Hide main and pause menus
-	escoria.game_scene.hide_main_menu()
-	escoria.game_scene.unpause_game()
+	
+		# Hide main and pause menus
+		escoria.game_scene.hide_main_menu()
+		escoria.game_scene.unpause_game()
 
 	# If FORCE_LAST_SCENE_NULL is true, force ESC_LAST_SCENE to empty
 	if escoria.globals_manager.get_global("FORCE_LAST_SCENE_NULL"):


### PR DESCRIPTION
Recent change in ESC_LAST_SCENE so that it was set too early resulted in this variable containing the current room id after the room was loaded, instead of the last one.

This "incorrect" change was necessary though for the transitions management between change_scene and ESCRoom.
As a side issue, I had to make ESCRoom manage unpause if in certain cases (happening when accessing room14 using room selector: in this case ESC_LAST_SCENE is null ; using 4th button for the first time in this case will have to deal with this).

Problem was that, in this case, change_scene does not play automatic transition, so the ESCRoom does, and it will now have to hide main/pause menus.