### PR TITLE
fix: Fixes smaller things

### DIFF
--- a/addons/escoria-core/game/core-scripts/behaviors/esc_movable.gd
+++ b/addons/escoria-core/game/core-scripts/behaviors/esc_movable.gd
@@ -318,6 +318,8 @@ func update_terrain(on_event_finished_name = null) -> void:
 		return
 	if parent.get("dont_apply_terrain_scaling"):
 		return
+	if not parent.is_inside_tree():
+		return
 		
 	var pos = parent.global_position
 	if pos.y <= VisualServer.CANVAS_ITEM_Z_MAX:

--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -471,6 +471,12 @@ func stop_talking():
 		)
 
 
+# Replay the last idle animation
+func update_idle():
+	get_animation_player().play(
+		animations.idles[_movable.last_dir].animation
+	)
+
 
 # Return the camera position if a camera_position_node exists or the
 # global position of the player

--- a/addons/escoria-core/game/core-scripts/esc_player.gd
+++ b/addons/escoria-core/game/core-scripts/esc_player.gd
@@ -21,4 +21,5 @@ func _ready():
 		._ready()
 	else:
 		tooltip_name = ""
-		disconnect("input_event", self, "manage_input")
+		if is_connected("input_event", self, "manage_input"):
+			disconnect("input_event", self, "manage_input")

--- a/addons/escoria-core/game/core-scripts/esc_room.gd
+++ b/addons/escoria-core/game/core-scripts/esc_room.gd
@@ -107,6 +107,7 @@ func _ready():
 				player.animations = ResourceLoader.load(
 					animations[player.global_id]
 				)
+				player.update_idle()
 		escoria.object_manager.get_object("_camera").node.set_target(player)
 	
 	for n in get_children():

--- a/addons/escoria-ui-9verbs/verbs_menu.gd
+++ b/addons/escoria-ui-9verbs/verbs_menu.gd
@@ -13,6 +13,10 @@ func _ready():
 		but.toggle_mode = true
 
 func _on_action_selected(action: String):
+	if escoria.inputs_manager.input_mode != escoria.inputs_manager.INPUT_ALL:
+		unselect_actions()
+		return
+
 	escoria.action_manager.set_current_action(action)
 
 	for but in get_children():


### PR DESCRIPTION
Fix player sprite not showing correct idle animation after animations change in room switch
Remove some more error outputs (godot-escoria/escoria-issues#64)
Fix verbs menu button selection when input mode is not all