### PR TITLE
Fix: makes dialog players pausable by removing yields

### DIFF
--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -5,6 +5,12 @@ extends Node
 # Signal sent when pause menu has to be displayed
 signal request_pause_menu
 
+# Signal sent when Escoria is paused
+signal paused
+
+# Signal sent when Escoria is resumed from pause
+signal resumed
+
 
 # Escoria version number
 const ESCORIA_VERSION = "0.1.0"
@@ -317,6 +323,10 @@ func _input(event):
 # #### Parameters
 # - p_paused: if true, pauses the game. If false, unpauses the game.
 func set_game_paused(p_paused: bool):
+	if p_paused:
+		emit_signal("paused")
+	else:
+		emit_signal("resumed")
 	get_tree().paused = p_paused
 
 

--- a/addons/escoria-core/game/scenes/dialogs/esc_dialog_player.gd
+++ b/addons/escoria-core/game/scenes/dialogs/esc_dialog_player.gd
@@ -44,7 +44,7 @@ func _ready():
 # - event: The input event
 func _input(event):
 	if event is InputEventMouseButton and event.pressed \
-			and is_speaking and not _dialog_manager.type_player.is_paused:
+			and is_speaking and not _dialog_manager.get_type_player().is_paused:
 		speedup()
 		get_tree().set_input_as_handled()
 		

--- a/addons/escoria-core/game/scenes/dialogs/esc_dialog_player.gd
+++ b/addons/escoria-core/game/scenes/dialogs/esc_dialog_player.gd
@@ -44,7 +44,7 @@ func _ready():
 # - event: The input event
 func _input(event):
 	if event is InputEventMouseButton and event.pressed \
-			and is_speaking:
+			and is_speaking and not _dialog_manager.type_player.is_paused:
 		speedup()
 		get_tree().set_input_as_handled()
 		
@@ -108,6 +108,9 @@ func say(character: String, type: String, text: String) -> void:
 				"No dialog manager supports the type %s" % type
 			]
 		)
+	
+	_dialog_manager.connect("say_finished", self, "_on_say_finished", [], CONNECT_ONESHOT)
+	
 	var matches = _keytext_regex.search(text)
 	if not matches:
 		escoria.logger.report_errors(
@@ -130,11 +133,14 @@ func say(character: String, type: String, text: String) -> void:
 	else:
 		text = matches.get_string("text")
 	
-	_dialog_manager.say(self, character, text, type)	
-	yield(_dialog_manager, "say_finished")
+	_dialog_manager.say(self, character, text, type)
+
+
+# Handles the end of a say function after it has emitted say_finished.
+func _on_say_finished():
 	is_speaking = false
 	emit_signal("say_finished")
-	
+
 
 # Called when a dialog line is skipped
 func speedup() -> void:

--- a/addons/escoria-core/game/scenes/sound/esc_music_player.gd
+++ b/addons/escoria-core/game/scenes/sound/esc_music_player.gd
@@ -51,6 +51,7 @@ func set_state(p_state: String, p_force: bool = false) -> void:
 
 # Register to the object registry
 func _ready():
+	pause_mode = Node.PAUSE_MODE_STOP
 	escoria.object_manager.register_object(
 		ESCObject.new(global_id, self),
 		true

--- a/addons/escoria-core/game/scenes/sound/esc_sound_player.gd
+++ b/addons/escoria-core/game/scenes/sound/esc_sound_player.gd
@@ -50,6 +50,7 @@ func set_state(p_state: String, p_force: bool = false):
 
 # Register to the object registry
 func _ready():
+	pause_mode = Node.PAUSE_MODE_STOP
 	escoria.object_manager.register_object(
 		ESCObject.new(global_id, self),
 		true

--- a/addons/escoria-core/game/scenes/sound/esc_speech_player.gd
+++ b/addons/escoria-core/game/scenes/sound/esc_speech_player.gd
@@ -34,6 +34,7 @@ func set_state(p_state: String, p_force: bool = false) -> void:
 
 # Register to the object registry
 func _ready():
+	pause_mode = Node.PAUSE_MODE_STOP
 	escoria.object_manager.register_object(
 		ESCObject.new(global_id, self),
 		true

--- a/addons/escoria-dialog-simple/esc_dialog_simple.gd
+++ b/addons/escoria-dialog-simple/esc_dialog_simple.gd
@@ -4,7 +4,7 @@ class_name ESCDialogSimple
 
 
 # The currently running player
-var type_player: Node = null
+var _type_player: Node = null
 
 # Reference to the dialog player
 var _dialog_player: Node = null
@@ -42,27 +42,27 @@ func has_chooser_type(type: String) -> bool:
 func say(dialog_player: Node, global_id: String, text: String, type: String):
 	_dialog_player = dialog_player
 	if type == "floating":
-		type_player = preload(\
+		_type_player = preload(\
 			"res://addons/escoria-dialog-simple/types/floating.tscn"\
 		).instance()
 	else:
-		type_player = preload(\
+		_type_player = preload(\
 			"res://addons/escoria-dialog-simple/types/avatar.tscn"\
 		).instance()
 		
-	type_player.connect("say_finished", self, "_on_say_finished", [], CONNECT_ONESHOT)
+	_type_player.connect("say_finished", self, "_on_say_finished", [], CONNECT_ONESHOT)
 	
-	_dialog_player.add_child(type_player)
-	type_player.say(global_id, text)
-#	yield(type_player, "say_finished")
-#	if _dialog_player.get_children().has(type_player):
-#		_dialog_player.remove_child(type_player)
+	_dialog_player.add_child(_type_player)
+	_type_player.say(global_id, text)
+#	yield(_type_player, "say_finished")
+#	if _dialog_player.get_children().has(_type_player):
+#		_dialog_player.remove_child(_type_player)
 #		emit_signal("say_finished")
 
 
 func _on_say_finished():
-	if _dialog_player.get_children().has(type_player):
-		_dialog_player.remove_child(type_player)
+	if _dialog_player.get_children().has(_type_player):
+		_dialog_player.remove_child(_type_player)
 		emit_signal("say_finished")
 
 
@@ -86,19 +86,19 @@ func choose(dialog_player: Node, dialog: ESCDialog):
 
 # Trigger running the dialog faster
 func speedup():
-	if type_player != null:
-		type_player.speedup()
+	if _type_player != null:
+		_type_player.speedup()
 
 
 # The say command has been interrupted, cancel the dialog display
 func interrupt():
-	if _dialog_player.get_children().has(type_player):
-		_dialog_player.remove_child(type_player)
+	if _dialog_player.get_children().has(_type_player):
+		_dialog_player.remove_child(_type_player)
 		emit_signal("say_finished")
 
 
 # Getter for the type player
 #
 # *Returns* the type player
-func gettype_player() -> Node:
-	return type_player
+func get_type_player() -> Node:
+	return _type_player

--- a/addons/escoria-dialog-simple/esc_dialog_simple.gd
+++ b/addons/escoria-dialog-simple/esc_dialog_simple.gd
@@ -4,7 +4,7 @@ class_name ESCDialogSimple
 
 
 # The currently running player
-var _type_player: Node = null
+var type_player: Node = null
 
 # Reference to the dialog player
 var _dialog_player: Node = null
@@ -42,18 +42,27 @@ func has_chooser_type(type: String) -> bool:
 func say(dialog_player: Node, global_id: String, text: String, type: String):
 	_dialog_player = dialog_player
 	if type == "floating":
-		_type_player = preload(\
+		type_player = preload(\
 			"res://addons/escoria-dialog-simple/types/floating.tscn"\
 		).instance()
 	else:
-		_type_player = preload(\
+		type_player = preload(\
 			"res://addons/escoria-dialog-simple/types/avatar.tscn"\
 		).instance()
-	_dialog_player.add_child(_type_player)
-	_type_player.say(global_id, text)
-	yield(_type_player, "say_finished")
-	if _dialog_player.get_children().has(_type_player):
-		_dialog_player.remove_child(_type_player)
+		
+	type_player.connect("say_finished", self, "_on_say_finished", [], CONNECT_ONESHOT)
+	
+	_dialog_player.add_child(type_player)
+	type_player.say(global_id, text)
+#	yield(type_player, "say_finished")
+#	if _dialog_player.get_children().has(type_player):
+#		_dialog_player.remove_child(type_player)
+#		emit_signal("say_finished")
+
+
+func _on_say_finished():
+	if _dialog_player.get_children().has(type_player):
+		_dialog_player.remove_child(type_player)
 		emit_signal("say_finished")
 
 
@@ -77,12 +86,19 @@ func choose(dialog_player: Node, dialog: ESCDialog):
 
 # Trigger running the dialog faster
 func speedup():
-	if _type_player != null:
-		_type_player.speedup()
+	if type_player != null:
+		type_player.speedup()
 
 
 # The say command has been interrupted, cancel the dialog display
 func interrupt():
-	if _dialog_player.get_children().has(_type_player):
-		_dialog_player.remove_child(_type_player)
+	if _dialog_player.get_children().has(type_player):
+		_dialog_player.remove_child(type_player)
 		emit_signal("say_finished")
+
+
+# Getter for the type player
+#
+# *Returns* the type player
+func gettype_player() -> Node:
+	return type_player

--- a/addons/escoria-dialog-simple/types/avatar.gd
+++ b/addons/escoria-dialog-simple/types/avatar.gd
@@ -29,10 +29,13 @@ onready var text_node = $Panel/MarginContainer/HSplitContainer/text
 # The tween node for text animations
 onready var tween = $Panel/MarginContainer/HSplitContainer/text/Tween
 
+# Whether the dialog manager is paused
+onready var is_paused: bool = true
+
+
 
 # Build up the UI
 func _ready():
-	pause_mode = PAUSE_MODE_STOP
 	_text_speed_per_character = ProjectSettings.get_setting(
 		"escoria/dialog_simple/text_speed_per_character"
 	)
@@ -48,6 +51,9 @@ func _ready():
 		self, 
 		"_on_dialog_line_typed"
 	)
+	
+	escoria.connect("paused", self, "_on_paused")
+	escoria.connect("resumed", self, "_on_resumed")
 
 
 # Switch the current character
@@ -108,3 +114,16 @@ func _on_dialog_finished():
 	emit_signal("say_finished")
 	queue_free()
 
+
+# Handler managing pause notification from Escoria
+func _on_paused():
+	if tween.is_active():
+		is_paused = true
+		tween.stop_all()
+
+
+# Handler managing resume notification from Escoria
+func _on_resumed():
+	if not tween.is_active():
+		is_paused = false
+		tween.resume_all()

--- a/addons/escoria-dialog-simple/types/floating.gd
+++ b/addons/escoria-dialog-simple/types/floating.gd
@@ -29,10 +29,12 @@ onready var tween: Tween = $Tween
 # The node showing the text
 onready var text_node: RichTextLabel = self
 
+# Whether the dialog manager is paused
+onready var is_paused: bool = true
+
 
 # Enable bbcode and catch the signal when a tween completed
 func _ready():
-	pause_mode = PAUSE_MODE_STOP
 	_text_speed_per_character = ProjectSettings.get_setting(
 		"escoria/dialog_simple/text_speed_per_character"
 	)
@@ -44,7 +46,10 @@ func _ready():
 	)
 	bbcode_enabled = true
 	$Tween.connect("tween_completed", self, "_on_dialog_line_typed")
-
+	
+	escoria.connect("paused", self, "_on_paused")
+	escoria.connect("resumed", self, "_on_resumed")
+	
 
 func _process(delta):
 	if _current_character.is_inside_tree() and \
@@ -140,3 +145,17 @@ func _on_dialog_finished():
 	if is_instance_valid(_current_character) and _current_character != null:
 		_current_character.stop_talking()
 	emit_signal("say_finished")
+	
+
+# Handler managing pause notification from Escoria
+func _on_paused():
+	if tween.is_active():
+		is_paused = true
+		tween.stop_all()
+
+
+# Handler managing resume notification from Escoria
+func _on_resumed():
+	if not tween.is_active():
+		is_paused = false
+		tween.resume_all()

--- a/addons/escoria-dialog-simple/types/floating.tscn
+++ b/addons/escoria-dialog-simple/types/floating.tscn
@@ -13,7 +13,6 @@ script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
-text_speed_per_character = 0.0
 
 [node name="Tween" type="Tween" parent="."]
 

--- a/addons/escoria-ui-9verbs/game.tscn
+++ b/addons/escoria-ui-9verbs/game.tscn
@@ -19,6 +19,15 @@ script = ExtResource( 5 )
 main_menu = NodePath("ui/main_menu")
 pause_menu = NodePath("ui/pause_menu")
 
+[node name="dialog_layer" type="CanvasLayer" parent="."]
+
+[node name="ESCDialogsPlayer" type="Control" parent="dialog_layer"]
+theme = ExtResource( 10 )
+script = ExtResource( 4 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
 [node name="ui" type="CanvasLayer" parent="."]
 
 [node name="Control" type="Control" parent="ui"]
@@ -136,16 +145,6 @@ margin_right = 404.0
 margin_bottom = 200.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-
-[node name="dialog_layer" type="CanvasLayer" parent="ui"]
-layer = 3
-
-[node name="ESCDialogsPlayer" type="Control" parent="ui/dialog_layer"]
-theme = ExtResource( 10 )
-script = ExtResource( 4 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="hover_stack" type="Label" parent="ui"]
 margin_left = 1085.0

--- a/addons/escoria-ui-simplemouse/game.tscn
+++ b/addons/escoria-ui-simplemouse/game.tscn
@@ -18,6 +18,16 @@ editor_debug_mode = 1
 
 [node name="camera" parent="." instance=ExtResource( 3 )]
 
+[node name="dialog_layer" type="CanvasLayer" parent="."]
+layer = 3
+
+[node name="ESCDialogsPlayer" type="Control" parent="dialog_layer"]
+theme = ExtResource( 9 )
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
 [node name="ui" type="Control" parent="CanvasLayer"]
@@ -69,16 +79,6 @@ theme = ExtResource( 9 )
 
 [node name="main_menu" parent="CanvasLayer" instance=ExtResource( 7 )]
 visible = false
-
-[node name="dialog_layer" type="CanvasLayer" parent="."]
-layer = 3
-
-[node name="ESCDialogsPlayer" type="Control" parent="dialog_layer"]
-theme = ExtResource( 9 )
-script = ExtResource( 2 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="tooltip_layer" type="CanvasLayer" parent="."]
 layer = 2


### PR DESCRIPTION
Fixes a blocking issue happening when pausing the game (ESC key) while a say line was ongoing: dialog line was yielding for say_finished signal, thus blocking pause menu