### PR TITLE
feat: add esc_current_scene reserved global

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
@@ -66,13 +66,14 @@ func run(command_params: Array) -> int:
 	# exit_scene event. Also room selector actions require the transition.
 	if command_params[1] \
 			and (
-				not escoria.globals_manager.get_global("ESC_LAST_SCENE").empty()
+				not escoria.globals_manager.get_global( \
+					escoria.room_manager.GLOBAL_LAST_SCENE).empty()
 				or (
 					escoria.event_manager.get_running_event("_front") != null \
 					and escoria.event_manager.get_running_event("_front").name \
 						in ["newgame", "exit_scene", "room_selector"]
 						and escoria.globals_manager.get_global(
-							"ESC_LAST_SCENE"
+							escoria.room_manager.GLOBAL_LAST_SCENE
 						).empty()
 					)
 				):
@@ -91,16 +92,18 @@ func run(command_params: Array) -> int:
 		escoria.game_scene.unpause_game()
 
 	# If FORCE_LAST_SCENE_NULL is true, force ESC_LAST_SCENE to empty
-	if escoria.globals_manager.get_global("FORCE_LAST_SCENE_NULL"):
+	if escoria.globals_manager.get_global( \
+		escoria.room_manager.GLOBAL_FORCE_LAST_SCENE_NULL):
+
 		escoria.globals_manager.set_global(
-			"ESC_LAST_SCENE", 
+			escoria.room_manager.GLOBAL_LAST_SCENE, 
 			null, 
 			true
 		)
 	elif escoria.main.current_scene:
 		# If FORCE_LAST_SCENE_NULL is false, set ESC_LAST_SCENE = current roomid
 		escoria.globals_manager.set_global(
-			"ESC_LAST_SCENE", 
+			escoria.room_manager.GLOBAL_LAST_SCENE, 
 			escoria.main.current_scene.global_id, 
 			true
 		)
@@ -150,6 +153,14 @@ func run(command_params: Array) -> int:
 		room_scene.game = escoria.game_scene
 		escoria.main.set_scene(room_scene)
 		
+		# We know the scene has been loaded. Make its global ID available for
+		# use by ESC script.
+		escoria.globals_manager.set_global(
+			escoria.room_manager.GLOBAL_CURRENT_SCENE, 
+			room_scene.global_id, 
+			true
+		)
+
 		# Clear queued resources
 		escoria.resource_cache.clear()
 		

--- a/addons/escoria-core/game/core-scripts/esc/esc_globals_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_globals_manager.gd
@@ -13,6 +13,7 @@ signal global_changed(global, old_value, new_value)
 export(Dictionary) var _globals = {}
 
 
+# Registry of globals that are to be reserved for internal use only.
 var _reserved_globals: Dictionary = {}
 
 
@@ -42,7 +43,9 @@ func register_reserved_global(key: String, value = null) -> void:
 		)
 	_reserved_globals[key] = value
 	_globals[key] = value
-	emit_signal("global_changed", key, _globals[key], value)
+	
+	if value != null:
+		emit_signal("global_changed", key, _globals[key], value)
 	
 
 # Get the current value of a global

--- a/addons/escoria-core/game/core-scripts/esc/esc_globals_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_globals_manager.gd
@@ -5,30 +5,15 @@ extends Resource
 class_name ESCGlobalsManager
 
 
-const GLOBAL_ANIMATION_RESOURCES = "ANIMATION_RESOURCES"
-
-
 # Emitted when a global is changed
 signal global_changed(global, old_value, new_value)
-
-
-# A list of reserved globals which can not be overridden
-const RESERVED_GLOBALS = [
-	"ESC_LAST_SCENE",		# Contains the global_id of previous room
-	"FORCE_LAST_SCENE_NULL",	# If true, ESC_LAST_SCENE is not considered for 
-							# automatic transitions
-	"ANIMATION_RESOURCES"
-]
 
 
 # The globals registry
 export(Dictionary) var _globals = {}
 
 
-
-func _init():
-	set_global("ESC_LAST_SCENE", "", true)
-	set_global("FORCE_LAST_SCENE_NULL", false, true)
+var _reserved_globals: Dictionary = {}
 
 
 # Check if a global was registered
@@ -40,6 +25,25 @@ func _init():
 func has(key: String) -> bool:
 	return _globals.has(key)
 
+
+# Registers a global as being reserved and initializes it.
+#
+# #### Parameters
+#
+# - key: The key of the global to register
+# - value: The initial value (optional)
+func register_reserved_global(key: String, value = null) -> void:
+	if key in _reserved_globals:
+		escoria.logger.report_errors(
+			"ESCGlobalsManager.register_reserved_global: Can not override reserved global",
+			[
+				"Global key %s is already registered as reserved" % key
+			]
+		)
+	_reserved_globals[key] = value
+	_globals[key] = value
+	emit_signal("global_changed", key, _globals[key], value)
+	
 
 # Get the current value of a global
 #
@@ -77,7 +81,7 @@ func filter(pattern: String) -> Dictionary:
 # - key: The key of the global to modify
 # - value: The new value
 func set_global(key: String, value, ignore_reserved: bool = false) -> void:
-	if key in RESERVED_GLOBALS and not ignore_reserved:
+	if key in _reserved_globals and not ignore_reserved:
 		escoria.logger.report_errors(
 			"ESCGlobalsManager.set_global: Can not override reserved global",
 			[

--- a/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
@@ -1,0 +1,32 @@
+extends Object
+class_name ESCRoomManager
+
+
+# Reserved globals which can not be overridden; prefixed with "GLOBAL_"
+#
+# Contains the global_id of previous room
+const GLOBAL_LAST_SCENE = "ESC_LAST_SCENE"
+
+# If true, ESC_LAST_SCENE is not considered for automatic transitions
+const GLOBAL_FORCE_LAST_SCENE_NULL = "FORCE_LAST_SCENE_NULL"
+
+const GLOBAL_ANIMATION_RESOURCES = "ANIMATION_RESOURCES"
+
+# Contains the global_id of the current room
+const GLOBAL_CURRENT_SCENE = "ESC_CURRENT_SCENE"
+
+# Dict of the reserved globals to register and their initial values.
+const RESERVED_GLOBALS = {
+	GLOBAL_LAST_SCENE: "",
+	GLOBAL_FORCE_LAST_SCENE_NULL: false,
+	GLOBAL_ANIMATION_RESOURCES: [],
+	GLOBAL_CURRENT_SCENE: ""
+}
+
+
+# Registers all reserved global flags for use.
+func register_reserved_globals() -> void:
+	for key in RESERVED_GLOBALS:
+		escoria.globals_manager.register_reserved_global( \
+			key, 
+			RESERVED_GLOBALS[key])

--- a/addons/escoria-core/game/core-scripts/esc_room.gd
+++ b/addons/escoria-core/game/core-scripts/esc_room.gd
@@ -96,10 +96,10 @@ func _ready():
 			true
 		)
 		if escoria.globals_manager.has(
-			escoria.globals_manager.GLOBAL_ANIMATION_RESOURCES
+			escoria.room_manager.GLOBAL_ANIMATION_RESOURCES
 		):
 			var animations = escoria.globals_manager.get_global(
-				escoria.globals_manager.GLOBAL_ANIMATION_RESOURCES
+				escoria.room_manager.GLOBAL_ANIMATION_RESOURCES
 			)
 			
 			if player.global_id in animations and \
@@ -168,7 +168,8 @@ func perform_script_events():
 		if enabled_automatic_transitions \
 				or (
 					not enabled_automatic_transitions \
-					and escoria.globals_manager.get_global("FORCE_LAST_SCENE_NULL")
+					and escoria.globals_manager.get_global( \
+						escoria.room_manager.GLOBAL_FORCE_LAST_SCENE_NULL)
 				):
 			var script_transition_in = escoria.esc_compiler.compile([
 				":transition_in",
@@ -195,18 +196,28 @@ func perform_script_events():
 		
 		# Now that :ready is finished, if FORCE_LAST_SCENE_NULL was true, reset it 
 		# to false
-		if escoria.globals_manager.get_global("FORCE_LAST_SCENE_NULL"):
+		if escoria.globals_manager.get_global( \
+			escoria.room_manager.GLOBAL_FORCE_LAST_SCENE_NULL):
+
 			escoria.globals_manager.set_global(
-				"FORCE_LAST_SCENE_NULL", 
+				escoria.room_manager.GLOBAL_FORCE_LAST_SCENE_NULL, 
 				false, 
 				true
 			)
 			escoria.globals_manager.set_global(
-				"ESC_LAST_SCENE",
+				escoria.room_manager.GLOBAL_LAST_SCENE,
 				escoria.main.current_scene.global_id \
 						if escoria.main.current_scene != null else "", 
 				true
 			)
+		
+		# Make the room's global ID available for use in ESC script.
+		escoria.globals_manager.set_global(
+			escoria.room_manager.GLOBAL_CURRENT_SCENE,
+			escoria.main.current_scene.global_id \
+					if escoria.main.current_scene != null else "", 
+			true
+		)
 
 
 # Runs the script event from the script attached, if any.

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -41,6 +41,9 @@ var event_manager: ESCEventManager
 # ESC globals registry instance
 var globals_manager: ESCGlobalsManager
 
+# ESC room manager instance
+var room_manager: ESCRoomManager
+
 # ESC object manager instance
 var object_manager: ESCObjectManager
 
@@ -107,6 +110,7 @@ func _init():
 	self.save_manager = ESCSaveManager.new()
 	self.inputs_manager = ESCInputsManager.new()
 	self.controller = ESCController.new()
+	self.room_manager = ESCRoomManager.new()
 	
 	settings = ESCSaveSettings.new()
 	
@@ -124,6 +128,7 @@ func _init():
 func _ready():
 	settings = save_manager.load_settings()
 	apply_settings(settings)
+	room_manager.register_reserved_globals()
 	inputs_manager.register_core()
 	if ProjectSettings.get_setting("escoria/main/game_start_script").empty():
 		logger.report_errors("escoria.gd", 

--- a/addons/escoria-core/ui_library/tools/room_select/room_select.gd
+++ b/addons/escoria-core/ui_library/tools/room_select/room_select.gd
@@ -54,10 +54,11 @@ func _on_button_pressed():
 	# automatic transitions. 
 	# If FORCE_LAST_SCENE_NULL is True when change_scene starts:
 	# - ESC_LAST_SCENE is set to empty
-	escoria.globals_manager.set_global( \
+	escoria.globals_manager.set_global(
 		escoria.room_manager.GLOBAL_FORCE_LAST_SCENE_NULL,
 		true,
-		true)
+		true
+	)
 
 	var script = escoria.esc_compiler.compile([
 		":room_selector",

--- a/addons/escoria-core/ui_library/tools/room_select/room_select.gd
+++ b/addons/escoria-core/ui_library/tools/room_select/room_select.gd
@@ -55,7 +55,9 @@ func _on_button_pressed():
 	# If FORCE_LAST_SCENE_NULL is True when change_scene starts:
 	# - ESC_LAST_SCENE is set to empty
 	escoria.globals_manager.set_global( \
-		escoria.room_manager.GLOBAL_FORCE_LAST_SCENE_NULL, true, true)
+		escoria.room_manager.GLOBAL_FORCE_LAST_SCENE_NULL,
+		true,
+		true)
 
 	var script = escoria.esc_compiler.compile([
 		":room_selector",

--- a/addons/escoria-core/ui_library/tools/room_select/room_select.gd
+++ b/addons/escoria-core/ui_library/tools/room_select/room_select.gd
@@ -54,7 +54,9 @@ func _on_button_pressed():
 	# automatic transitions. 
 	# If FORCE_LAST_SCENE_NULL is True when change_scene starts:
 	# - ESC_LAST_SCENE is set to empty
-	escoria.globals_manager.set_global("FORCE_LAST_SCENE_NULL", true, true)
+	escoria.globals_manager.set_global( \
+		escoria.room_manager.GLOBAL_FORCE_LAST_SCENE_NULL, true, true)
+
 	var script = escoria.esc_compiler.compile([
 		":room_selector",
 		"change_scene %s" % _options_paths[_selected_id]

--- a/game/rooms/room15/esc/right_exit.esc
+++ b/game/rooms/room15/esc/right_exit.esc
@@ -1,0 +1,3 @@
+:exit_scene
+play_snd res://game/sfx/sounds/doorOpen_2.ogg
+change_scene "res://game/rooms/room16/room16.tscn"

--- a/game/rooms/room16/background.tscn
+++ b/game/rooms/room16/background.tscn
@@ -1,0 +1,30 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/escoria-core/game/core-scripts/esc_background.gd" type="Script" id=1]
+
+[node name="background" type="TextureRect"]
+margin_right = 1289.0
+margin_bottom = 555.0
+mouse_filter = 2
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="l_platform" type="Line2D" parent="."]
+position = Vector2( 2, -266 )
+points = PoolVector2Array( -2.96298, 712.01, 129.973, 614.429, 1167.5, 612.894, 1274.59, 669.705, 1273.25, 812.694, 2.36697, 811.043, 2.36697, 713.389 )
+
+[node name="l_door" type="Line2D" parent="."]
+position = Vector2( 0, -266 )
+points = PoolVector2Array( 6.61201, 704.409, 6.61203, 389.558, 87.755, 339.775, 87.5463, 649.784 )
+__meta__ = {
+"_editor_description_": ""
+}
+
+[node name="r_door" type="Line2D" parent="."]
+position = Vector2( 0, -267.828 )
+points = PoolVector2Array( 1175.07, 620.086, 1171.24, 311.267, 1274.8, 356.87, 1278.31, 672.412, 1188.64, 624.843 )
+__meta__ = {
+"_editor_description_": ""
+}

--- a/game/rooms/room16/esc/current_scene_button.esc
+++ b/game/rooms/room16/esc/current_scene_button.esc
@@ -1,0 +1,11 @@
+:use
+
+> [eq ESC_CURRENT_SCENE room16]
+	say player "This sure looks like room 16."
+	
+> [eq ESC_CURRENT_SCENE ESC_LAST_SCENE]
+	say player "I'll never say this."
+
+> [eq ESC_CURRENT_SCENE room1]
+	say player "I'll never say this, either."
+

--- a/game/rooms/room16/esc/left_exit.esc
+++ b/game/rooms/room16/esc/left_exit.esc
@@ -1,0 +1,3 @@
+:exit_scene
+play_snd res://game/sfx/sounds/doorOpen_2.ogg
+change_scene "res://game/rooms/room15/room15.tscn"

--- a/game/rooms/room16/esc/room16.esc
+++ b/game/rooms/room16/esc/room16.esc
@@ -1,0 +1,8 @@
+:setup
+
+> [eq ESC_LAST_SCENE room15]
+	teleport player r16_l_exit
+	# Set player look right
+	set_angle player 90
+	stop
+

--- a/game/rooms/room16/room16.tscn
+++ b/game/rooms/room16/room16.tscn
@@ -1,12 +1,13 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=11 format=2]
 
 [ext_resource path="res://addons/escoria-core/game/core-scripts/esc_terrain.gd" type="Script" id=1]
-[ext_resource path="res://game/rooms/room15/background.tscn" type="PackedScene" id=2]
+[ext_resource path="res://game/rooms/room14/background.tscn" type="PackedScene" id=2]
 [ext_resource path="res://game/fonts/caslonantique.tres" type="DynamicFont" id=3]
-[ext_resource path="res://game/characters/mark2dir/mark2dir.tscn" type="PackedScene" id=4]
+[ext_resource path="res://game/characters/mark/mark.tscn" type="PackedScene" id=4]
 [ext_resource path="res://addons/escoria-core/game/core-scripts/esc_location.gd" type="Script" id=5]
 [ext_resource path="res://addons/escoria-core/game/core-scripts/esc_room.gd" type="Script" id=6]
 [ext_resource path="res://addons/escoria-core/game/core-scripts/esc_item.gd" type="Script" id=7]
+[ext_resource path="res://game/rooms/room14/r_door.tscn" type="PackedScene" id=8]
 [ext_resource path="res://game/items/escitems/button.tscn" type="PackedScene" id=9]
 
 [sub_resource type="NavigationPolygon" id=1]
@@ -14,12 +15,13 @@ vertices = PoolVector2Array( 1168.92, 640.557, 1182.53, 588.863, 1269.59, 622.87
 polygons = [ PoolIntArray( 0, 1, 2, 3 ), PoolIntArray( 4, 5, 0, 3, 6, 7 ), PoolIntArray( 8, 7, 6, 9 ), PoolIntArray( 9, 6, 10, 11, 12 ) ]
 outlines = [ PoolVector2Array( -6.44019, 711.297, 3.15687, 646.051, 59.2201, 628.698, 84.5821, 654.06, 129.634, 615.792, 386.666, 618.012, 864.626, 613.518, 1143.08, 613.35, 1168.92, 640.557, 1182.53, 588.863, 1269.59, 622.872, 1275.03, 799.721, -9.16094, 803.802 ) ]
 
-[node name="room15" type="Node2D"]
+[node name="room16" type="Node2D"]
 script = ExtResource( 6 )
 __meta__ = {
 "_edit_vertical_guides_": [  ]
 }
-global_id = "room15"
+global_id = "room16"
+esc_script = "res://game/rooms/room16/esc/room16.esc"
 player_scene = ExtResource( 4 )
 camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
 
@@ -29,21 +31,7 @@ camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
 margin_right = 92.0
 margin_bottom = 21.0
 custom_fonts/font = ExtResource( 3 )
-text = "ROOM 15"
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="description" type="Label" parent="background"]
-margin_left = 198.0
-margin_top = 97.0
-margin_right = 681.0
-margin_bottom = 142.0
-custom_fonts/font = ExtResource( 3 )
-text = "This room has no ESC Script attached so the player will spawn at 
-starting location if there is one. 
-
-If there is none, the player will spawn at origin (0,0), top-left corner of the screen. "
+text = "ROOM 16"
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -63,8 +51,8 @@ __meta__ = {
 [node name="l_door" type="Area2D" parent="Hotspots"]
 pause_mode = 1
 script = ExtResource( 7 )
-global_id = "r15_l_exit"
-esc_script = "res://game/rooms/room15/esc/left_exit.esc"
+global_id = "r16_l_exit"
+esc_script = "res://game/rooms/room16/esc/left_exit.esc"
 is_exit = true
 tooltip_name = "Left exit"
 default_action = "walk"
@@ -79,23 +67,9 @@ position = Vector2( 37.4521, 392.045 )
 script = ExtResource( 5 )
 global_id = "r12_l_exit"
 
-[node name="r_door" type="Area2D" parent="Hotspots"]
-pause_mode = 1
-script = ExtResource( 7 )
-global_id = "r15_r_exit"
-esc_script = "res://game/rooms/room15/esc/right_exit.esc"
-is_exit = true
-tooltip_name = "Right exit"
-default_action = "walk"
-dialog_color = Color( 1, 1, 1, 1 )
-animations = null
-
-[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Hotspots/r_door"]
-position = Vector2( 0, -1 )
-polygon = PoolVector2Array( 1177.94, 348.61, 1175.95, 45.3759, 1276.06, 92.0953, 1277.95, 399.407 )
-__meta__ = {
-"_editor_description_": ""
-}
+[node name="r_door" parent="Hotspots" instance=ExtResource( 8 )]
+global_id = ""
+esc_script = ""
 
 [node name="ESCLocation" type="Position2D" parent="Hotspots/r_door"]
 position = Vector2( 1231.78, 360.624 )
@@ -108,29 +82,21 @@ global_id = "start"
 is_start_location = true
 interaction_direction = 180
 
-[node name="say_long" parent="Hotspots" instance=ExtResource( 9 )]
-position = Vector2( 675.509, 0.950089 )
-global_id = "say_long"
-esc_script = "res://game/rooms/room15/esc/say_long.esc"
-tooltip_name = "Say long test right"
+[node name="current_scene_button" parent="." instance=ExtResource( 9 )]
+position = Vector2( 30, 0 )
+global_id = "current_scene_button"
+esc_script = "res://game/rooms/room16/esc/current_scene_button.esc"
 
-[node name="Position2D" type="Position2D" parent="Hotspots/say_long"]
-position = Vector2( 362.457, 358.656 )
+[node name="Position2D" type="Position2D" parent="current_scene_button"]
+position = Vector2( 336, 384 )
 
-[node name="switch_animation" parent="Hotspots" instance=ExtResource( 9 )]
-position = Vector2( 510.195, 3.80031 )
-global_id = "switch_animation"
-esc_script = "res://game/rooms/room15/esc/switch_animation.esc"
-tooltip_name = "Switch animation"
-
-[node name="Position2D" type="Position2D" parent="Hotspots/switch_animation"]
-position = Vector2( 362.457, 358.656 )
-
-[node name="say_long_left" parent="Hotspots" instance=ExtResource( 9 )]
-position = Vector2( -205.218, 2.85024 )
-global_id = "say_long_left"
-esc_script = "res://game/rooms/room15/esc/say_long.esc"
-tooltip_name = "Say long test left"
-
-[node name="Position2D" type="Position2D" parent="Hotspots/say_long_left"]
-position = Vector2( 362.457, 358.656 )
+[node name="Label" type="Label" parent="current_scene_button"]
+margin_left = 294.887
+margin_top = 199.561
+margin_right = 398.887
+margin_bottom = 213.561
+text = "Is this room 16?"
+align = 1
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/project.godot
+++ b/project.godot
@@ -299,6 +299,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/escoria-core/game/core-scripts/esc_room.gd"
 }, {
+"base": "Object",
+"class": "ESCRoomManager",
+"language": "GDScript",
+"path": "res://addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd"
+}, {
 "base": "Resource",
 "class": "ESCSaveGame",
 "language": "GDScript",
@@ -603,6 +608,7 @@ _global_script_class_icons={
 "ESCPlayer": "res://addons/escoria-core/design/esc_player.svg",
 "ESCResourceCache": "",
 "ESCRoom": "res://addons/escoria-core/design/esc_room.svg",
+"ESCRoomManager": "",
 "ESCSaveGame": "",
 "ESCSaveManager": "",
 "ESCSaveSettings": "",


### PR DESCRIPTION
New reserved global to hold current scene global ID to allow for flexibility in ESC scripts.
Also refactor reserved globals' handling for rooms with addition of ESCRoomManager and the elimination of string literals across multiple files. Allows for less chance of accidental errors as opposed to using string literals everywhere. As well, this encapsulates room-specific reserved globals and will serve as the basis for more room-specific behaviour management.