### PR TITLE
refactor: Whitespace removal from all .gd files

### DIFF
--- a/addons/escoria-core/_test/test_esc_compiler.gd
+++ b/addons/escoria-core/_test/test_esc_compiler.gd
@@ -13,7 +13,7 @@ func _test_basic() -> bool:
 	say player "Test3" [test2]
 	# Third group
 	>
-	
+
 		say player "Test4"
 # Fourth group
 >
@@ -22,41 +22,41 @@ func _test_basic() -> bool:
 	say player TEST:"Test 7"
 	"""
 	var script = escoria.esc_compiler.compile(esc.split("\n"))
-	
+
 	var subject = script
 	assert(subject is ESCScript)
-	
+
 	subject = script.events.keys()
 	assert(subject.size() == 1)
 	assert(subject[0] == "test")
-	
+
 	subject = script.events["test"].statements
 	assert(subject.size() == 2)
-	
+
 	subject = script.events["test"].statements[0]
 	assert(subject is ESCGroup)
 	assert(subject.statements.size() == 4)
-	
+
 	subject = script.events["test"].statements[0].statements[0]
 	assert(subject is ESCCommand)
 	assert(subject.name == "say")
 	assert(subject.parameters.size() == 2)
 	assert(subject.parameters[0] == "player")
 	assert(subject.parameters[1] == '"Test"')
-	
+
 	subject = script.events["test"].statements[0].statements[1]
 	assert(subject is ESCGroup)
 	assert(subject.conditions.size() == 1)
 	assert(subject.conditions[0] is ESCCondition)
 	assert(subject.conditions[0].flag == "test")
-	
+
 	subject = script.events["test"].statements[0].statements[1].statements[0]
 	assert(subject is ESCCommand)
 	assert(subject.name == "say")
 	assert(subject.parameters.size() == 2)
 	assert(subject.parameters[0] == "player")
 	assert(subject.parameters[1] == '"Test2 BLANK"')
-	
+
 	subject = script.events["test"].statements[0].statements[2]
 	assert(subject is ESCCommand)
 	assert(subject.name == "say")
@@ -65,27 +65,27 @@ func _test_basic() -> bool:
 	assert(subject.parameters[1] == '"Test3"')
 	assert(subject.conditions.size() == 1)
 	assert(subject.conditions[0].flag == "test2")
-	
+
 	subject = script.events["test"].statements[0].statements[3]
 	assert(subject is ESCGroup)
 	assert(subject.statements.size() == 1)
-	
+
 	subject = script.events["test"].statements[1]
 	assert(subject is ESCGroup)
 	assert(subject.statements.size() == 3)
-	
+
 	subject = script.events["test"].statements[1].statements[1]
 	assert(subject is ESCCommand)
 	assert(subject.name == "say")
-	assert(subject.parameters[1] == '"Test 6"')	
-	
+	assert(subject.parameters[1] == '"Test 6"')
+
 	subject = script.events["test"].statements[1].statements[2]
 	assert(subject is ESCCommand)
 	assert(subject.name == "say")
 	assert(subject.parameters[1] == "TEST:\"Test 7\"")
-	
+
 	return true
-	
+
 
 func _test_conditions() -> bool:
 	var esc = """
@@ -101,39 +101,39 @@ say player "Test" [eq flag 3,gt flag 5]
 say player "Test" [!eq flag 3]
 	"""
 	var script = escoria.esc_compiler.compile(esc.split("\n"))
-	
+
 	var subject = script.events["test"].statements[0]
 	assert(subject is ESCCommand)
 	assert(subject.conditions.size() == 1)
-	
+
 	subject = script.events["test"].statements[0].conditions[0]
 	assert(subject.flag == "flag")
 	assert(not subject.negated)
 	assert(not subject.inventory)
 	assert(subject.comparison == ESCCondition.COMPARISON_NONE)
-	
+
 	subject = script.events["test"].statements[1].conditions
 	assert(subject.size() == 2)
 	assert(subject[0].flag == "flag1")
 	assert(subject[1].flag == "flag2")
-	
+
 	subject = script.events["test"].statements[2].conditions
 	assert(subject.size() == 1)
 	assert(subject[0].flag == "flag")
 	assert(subject[0].negated)
-	
+
 	subject = script.events["test"].statements[3].conditions
 	assert(subject.size() == 1)
 	assert(subject[0].flag == "flag")
 	assert(subject[0].inventory)
-	
+
 	subject = script.events["test"].statements[4].conditions
 	assert(subject.size() == 2)
 	assert(subject[0].flag == "flag")
 	assert(subject[0].inventory)
 	assert(subject[1].flag == "flag")
 	assert(not subject[1].inventory)
-	
+
 	subject = script.events["test"].statements[5].conditions
 	assert(subject.size() == 3)
 	assert(subject[0].flag == "flag")
@@ -143,13 +143,13 @@ say player "Test" [!eq flag 3]
 	assert(subject[2].flag == "flag2")
 	assert(not subject[2].inventory)
 	assert(subject[2].negated)
-	
+
 	subject = script.events["test"].statements[6].conditions
 	assert(subject.size() == 1)
 	assert(subject[0].flag == "flag")
 	assert(subject[0].comparison == ESCCondition.COMPARISON_EQ)
 	assert(subject[0].comparison_value == 3)
-	
+
 	subject = script.events["test"].statements[7].conditions
 	assert(subject.size() == 2)
 	assert(subject[0].flag == "flag")
@@ -158,14 +158,14 @@ say player "Test" [!eq flag 3]
 	assert(subject[1].flag == "flag")
 	assert(subject[1].comparison == ESCCondition.COMPARISON_GT)
 	assert(subject[1].comparison_value == 5)
-	
+
 	subject = script.events["test"].statements[8].conditions
 	assert(subject.size() == 1)
 	assert(subject[0].flag == "flag")
 	assert(subject[0].comparison == ESCCondition.COMPARISON_EQ)
 	assert(subject[0].comparison_value == 3)
 	assert(subject[0].negated)
-	
+
 	return true
 
 
@@ -176,31 +176,31 @@ func _test_event_flags() -> bool:
 :test3 | TK NO_TT NO_UI
 	"""
 	var script = escoria.esc_compiler.compile(esc.split("\n"))
-	
+
 	var subject = script.events
 	assert(subject.keys().size() == 3)
 	assert("test" in subject.keys())
 	assert("test2" in subject.keys())
 	assert("test3" in subject.keys())
-	
+
 	subject = script.events["test"]
 	assert(subject.name == "test")
 	assert(subject.flags & ESCEvent.FLAG_TK != 0)
 	assert(subject.flags & ESCEvent.FLAG_NO_TT == 0)
-	
+
 	subject = script.events["test2"]
 	assert(subject.name == "test2")
 	assert(subject.flags & ESCEvent.FLAG_TK != 0)
 	assert(subject.flags & ESCEvent.FLAG_NO_TT != 0)
-	
+
 	subject = script.events["test3"]
 	assert(subject.name == "test3")
 	assert(subject.flags & ESCEvent.FLAG_TK != 0)
 	assert(subject.flags & ESCEvent.FLAG_NO_TT != 0)
 	assert(subject.flags & ESCEvent.FLAG_NO_UI != 0)
-		
+
 	return true
-	
+
 
 func _test_dialog() -> bool:
 	var esc = """
@@ -226,17 +226,17 @@ func _test_dialog() -> bool:
 !
 	"""
 	var script = escoria.esc_compiler.compile(esc.split("\n"))
-	
+
 	var subject = script.events["test"].statements
 	assert(subject.size() == 1)
 
 	assert(subject[0] is ESCDialog)
 	assert(subject[0].options.size() == 4)
-	
+
 	subject = script.events["test"].statements[0].options[0]
 	assert(subject is ESCDialogOption)
 	assert(subject.option == "Option 1")
-	
+
 	subject = script.events["test"].statements[0].options[0].statements
 	assert(subject.size() == 3)
 	assert(subject[0] is ESCCommand)
@@ -250,13 +250,13 @@ func _test_dialog() -> bool:
 	assert(subject[2].name == "say")
 	assert(subject[2].parameters.size() == 2)
 	assert(subject[2].parameters[1] == '"testb?"')
-	
+
 	subject = script.events["test"].statements[0].options[1]
 	assert(subject is ESCDialogOption)
 	assert(subject.option == "Option 2")
 	assert(subject.conditions.size() == 1)
 	assert(subject.conditions[0].flag == "flag")
-	
+
 	subject = script.events["test"].statements[0].options[1].statements
 	assert(subject.size() == 2)
 	assert(subject[0] is ESCCommand)
@@ -265,24 +265,24 @@ func _test_dialog() -> bool:
 
 	assert(subject[1] is ESCDialog)
 	assert(subject[1].options.size() == 2)
-		
+
 	subject = script.events["test"].statements[0].options[2]
 	assert(subject is ESCDialogOption)
 	assert(subject.option == "Option 3")
-	
+
 	subject = script.events["test"].statements[0].options[2].statements
 	assert(subject.size() == 1)
 	assert(subject[0] is ESCGroup)
 	assert(subject[0].statements.size() == 1)
 	assert(subject[0].statements[0] is ESCCommand)
 	assert(subject[0].statements[0].parameters.size() == 2)
-	
+
 	subject = script.events["test"].statements[0].options[3]
 	assert(subject is ESCDialogOption)
 	assert(subject.option == "TEST")
-	
+
 	return true
-	
+
 
 func _on_BasicFunctionality_pressed():
 	$VBoxContainer/VBoxContainer/BasicFunctionality.pressed = self._test_basic()

--- a/addons/escoria-core/_test/test_migrations.gd
+++ b/addons/escoria-core/_test/test_migrations.gd
@@ -4,9 +4,9 @@ extends Control
 
 func _on_CheckESCMigrationManager_pressed() -> bool:
 	var savegame: ESCSaveGame = ESCSaveGame.new()
-	
+
 	savegame.globals["test"] = "testa"
-	
+
 	var migration_manager: ESCMigrationManager = ESCMigrationManager.new()
 	savegame = migration_manager.migrate(
 		savegame,
@@ -14,7 +14,7 @@ func _on_CheckESCMigrationManager_pressed() -> bool:
 		"2.0.0",
 		"res://addons/escoria-core/_test/testversions"
 	)
-	
+
 	assert(savegame.globals["test"] == "testc")
-	
+
 	return true

--- a/addons/escoria-core/game/core-scripts/behaviors/esc_movable.gd
+++ b/addons/escoria-core/game/core-scripts/behaviors/esc_movable.gd
@@ -56,7 +56,7 @@ onready var task = MovableTask.NONE
 func _ready() -> void:
 	if not parent.has_user_signal("arrived"):
 		parent.add_user_signal("arrived")
-	
+
 
 # Main processing loop
 #
@@ -66,13 +66,13 @@ func _ready() -> void:
 func _process(delta: float) -> void:
 	if Engine.is_editor_hint():
 		return
-	
+
 	if task == MovableTask.WALK or task == MovableTask.SLIDE:
 		var old_pos = parent.get_position()
 		var new_pos = _calculate_movement(delta)
 		if new_pos == null:
 			return
-		
+
 		if task == MovableTask.WALK:
 			# Get the angle of the object to face the position to reach.
 			var angle: float = (old_pos.angle_to_point(new_pos))
@@ -96,24 +96,24 @@ func _calculate_movement(delta: float):
 	# Initialize the current pos and previous pos variables
 	var pos: Vector2 = parent.get_position()
 	var old_pos: Vector2 = pos
-	
+
 	# Get next waypoint from the walkpath array.
 	var next: Vector2
 	if walk_path.size() > 1:
 		next = walk_path[path_ofs + 1]
 	else:
 		next = walk_path[path_ofs]
-	
-	# Movement speed calculation 
+
+	# Movement speed calculation
 	var movement_speed: float = parent.speed * delta * pow(last_scale.x, 2) * \
 			parent.terrain.player_speed_multiplier
 	if walk_context.fast:
 		movement_speed *= parent.terrain.player_doubleclick_speed_multiplier
-	
+
 	# Calculate the direction vector from current position and next waypoint
 	var dir: Vector2 = (next - pos).normalized()
-	
-	# If we're close to the next waypoint (ie. distance < necessary movement 
+
+	# If we're close to the next waypoint (ie. distance < necessary movement
 	# speed to get to this waypoint, we consider the waypoint reached
 	# and pass to the next one.
 	# Else, calculate the new position.
@@ -129,27 +129,27 @@ func _calculate_movement(delta: float):
 	if path_ofs >= walk_path.size() - 1:
 		walk_stop(walk_destination)
 		return
-	
+
 	# Update current position variable
 	pos = new_pos
 	parent.set_position(pos)
 	return pos
 
-# Calculates the orientation of the object while walking, to play the right 
+# Calculates the orientation of the object while walking, to play the right
 # animation according to this orientation.
 #
 # #### Parameters
 #
-# - angle: the angle X axis and object's facing direction. 
+# - angle: the angle X axis and object's facing direction.
 func _perform_walk_orientation(angle: float):
 	last_dir = _get_dir_deg(escoria.utils.get_deg_from_rad(angle),
 		parent.animations)
 
 	var animation_player: ESCAnimationPlayer = \
 			parent.get_animation_player()
-	
+
 	var current_animation = animation_player.get_animation()
-	
+
 	var animation_to_play = \
 			parent.animations.directions[last_dir].animation
 	if current_animation != animation_to_play and \
@@ -168,7 +168,7 @@ func _perform_walk_orientation(angle: float):
 			],
 			true
 		)
-	
+
 	pose_scale = -1 if parent.animations.directions[last_dir].mirrored \
 		else 1
 
@@ -185,7 +185,7 @@ func teleport(target: Node) -> void:
 			"Object %s is teleported at position %s" % [
 				target.name,
 				parent.global_position
-			] 
+			]
 		)
 	elif "position" in target:
 		escoria.logger.info(
@@ -204,7 +204,7 @@ func teleport(target: Node) -> void:
 #
 # #### Parameters
 #
-# - target: Vector2 target position to teleport to 
+# - target: Vector2 target position to teleport to
 func teleport_to(target: Vector2) -> void:
 	escoria.logger.info(
 		"Object %s teleported to position %s" %
@@ -223,20 +223,20 @@ func walk_to(pos: Vector2, p_walk_context: ESCWalkContext = null) -> void:
 	if not parent.terrain:
 		walk_stop(parent.get_position())
 		return
-		
+
 	if task == MovableTask.WALK:
 		if walk_context.target_object == p_walk_context.target_object \
 				or walk_context.target_position \
 				== p_walk_context.target_position:
 			walk_context.fast = p_walk_context.fast
-	
+
 	walk_context = p_walk_context
-	
+
 	if task == MovableTask.NONE:
 		task = MovableTask.WALK
-	
+
 	walk_path = parent.terrain.get_simple_path(parent.get_position(), pos, true)
-	
+
 	if walk_path.size() == 0:
 		task = MovableTask.NONE
 		walk_stop(parent.get_position())
@@ -266,7 +266,7 @@ func walk_stop(pos: Vector2) -> void:
 	task = MovableTask.NONE
 	moved = false
 	set_process(false)
-	
+
 	# If we're heading to an object and reached its interaction position,
 	# orient towards the defined interaction direction set on the object
 	# (if any), can be ESCItem or ESCLocation
@@ -283,7 +283,7 @@ func walk_stop(pos: Vector2) -> void:
 			parent.animations.idles[last_dir].animation
 		)
 		pose_scale = -1 if parent.animations.idles[last_dir].mirrored else 1
-	
+
 	update_terrain()
 
 	if walk_context.target_object:
@@ -320,7 +320,7 @@ func update_terrain(on_event_finished_name = null) -> void:
 		return
 	if not parent.is_inside_tree():
 		return
-		
+
 	var pos = parent.global_position
 	if pos.y <= VisualServer.CANVAS_ITEM_Z_MAX:
 		parent.z_index = pos.y
@@ -332,12 +332,12 @@ func update_terrain(on_event_finished_name = null) -> void:
 	if scal != parent.get_scale():
 		last_scale = scal
 		parent.scale = last_scale
-		
+
 	var color = parent.terrain.get_light(pos)
 	parent.modulate = color
 
 	var sprite: Node = parent.get_sprite()
-	
+
 	# Do not flip the entire character, because that would conflict
 	# with shadows that expect to be siblings of $texture
 	if pose_scale == -1 and sprite.scale.x > 0:
@@ -360,7 +360,7 @@ func _get_dir_deg(deg: int, animations: ESCAnimationResource) -> int:
 	deg = wrapi(deg - 90, 0, 360)
 	var dir = -1
 	var i = 0
-	
+
 	for direction_angle in animations.dir_angles:
 		if _is_angle_in_interval(deg, direction_angle):
 			dir = i
@@ -375,7 +375,7 @@ func _get_dir_deg(deg: int, animations: ESCAnimationResource) -> int:
 			"esc_movable.gd:_get_dir_deg()",
 			["No direction found for " + str(deg)]
 		)
-	
+
 	return dir
 
 
@@ -386,18 +386,18 @@ func _get_dir_deg(deg: int, animations: ESCAnimationResource) -> int:
 #
 # - angle: Angle to test
 # - direction_angle: ESCDirectionAngle resource, containing the starting angle,
-#  and the size of interval 
+#  and the size of interval
 # eg: angle_start=90, angle_size=40 corresponds to angle between 90° and 130°
 func _is_angle_in_interval(
-		angle: float, 
+		angle: float,
 		direction_angle: ESCDirectionAngle
 ) -> bool:
 	var start_angle = direction_angle.angle_start
 	var end_angle = direction_angle.angle_start + direction_angle.angle_size
-	
+
 	if end_angle > 360 and angle < start_angle:
 		angle += 360
-	
+
 	return (start_angle <= angle and angle <= end_angle)
 
 
@@ -414,10 +414,10 @@ func set_angle(deg: int, wait: float = 0.0) -> void:
 			["Invalid degree to turn to " + str(deg)]
 		)
 	moved = true
-	
+
 	var current_dir = last_dir
 	var target_dir = _get_dir_deg(deg, parent.animations)
-	
+
 	var way_to_turn = get_shortest_way_to_dir(current_dir, target_dir)
 
 	var dir = current_dir
@@ -427,14 +427,14 @@ func set_angle(deg: int, wait: float = 0.0) -> void:
 			dir = 0
 		if dir < 0:
 			dir = parent.animations.dir_angles.size() - 1
-		
+
 		parent.get_animation_player().play(
 			parent.animations.idles[dir].animation
 		)
-		if wait > 0.0: 
+		if wait > 0.0:
 			yield(get_tree().create_timer(wait), "timeout")
 		pose_scale = -1 if parent.animations.idles[dir].mirrored else 1
-			
+
 	last_dir = _get_dir_deg(deg, parent.animations)
 
 	# The character may have a state animation from before, which would be
@@ -456,13 +456,13 @@ func set_angle(deg: int, wait: float = 0.0) -> void:
 func turn_to(item: Node, wait: float = 0.0) -> void:
 	set_angle(
 		wrapi(
-			rad2deg(parent.get_position().angle_to_point(item.get_position())), 
-			0, 
+			rad2deg(parent.get_position().angle_to_point(item.get_position())),
+			0,
 			360
 		),
 		wait
 	)
-	
+
 
 # Returns the angle that corresponds to the current direction of the object.
 func _get_angle() -> int:
@@ -470,8 +470,8 @@ func _get_angle() -> int:
 
 
 # Return the shortest way to turn from a direction to another. Returned way is
-# either: 
-# -1 (shortest way is to turn anti-clockwise) 
+# either:
+# -1 (shortest way is to turn anti-clockwise)
 # 0 (already at the right direction)
 # 1 (clockwise).
 #
@@ -489,23 +489,23 @@ func get_shortest_way_to_dir(current_dir: int, target_dir: int) -> int:
 			"esc_movable.gd:get_shortest_way_to_dir()",
 			["Invalid direction (current_dir) %s" % str(current_dir)]
 		)
-	
+
 	if target_dir < 0 or target_dir > parent.animations.dir_angles.size() - 1:
 		escoria.logger.report_errors(
 			"esc_movable.gd:get_shortest_way_to_dir()",
 			["Invalid direction (target_dir) %s " % str(target_dir)]
 		)
-	
+
 	if current_dir == target_dir:
 		return 0
-	
+
 	var internal = false
 	if max(current_dir, target_dir) - min(current_dir, target_dir) \
 			< parent.animations.dir_angles.size() / 2:
 		internal = true
 	else:
 		internal = false
-	
+
 	if internal and current_dir < target_dir or \
 			(not internal and current_dir > target_dir):
 		return 1

--- a/addons/escoria-core/game/core-scripts/esc/commands/accept_input.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/accept_input.gd
@@ -24,7 +24,7 @@ class_name AcceptInputCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		1, 
+		1,
 		[TYPE_STRING],
 		["ALL"]
 	)
@@ -52,6 +52,6 @@ func run(command_params: Array) -> int:
 			mode = escoria.inputs_manager.INPUT_NONE
 		"SKIP":
 			mode = escoria.inputs_manager.INPUT_SKIP
-	
+
 	escoria.inputs_manager.input_mode = mode
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc/commands/anim.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/anim.gd
@@ -1,7 +1,7 @@
 # `anim object name [reverse]`
 #
-# Executes the animation specified in "name" on "object", 
-# without blocking. The next command in the event will be executed immediately 
+# Executes the animation specified in "name" on "object",
+# without blocking. The next command in the event will be executed immediately
 # after.
 #
 # **Parameters**
@@ -18,12 +18,12 @@ class_name AnimCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING, TYPE_BOOL],
 		[null, null, false]
 	)
-	
-	
+
+
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):
 	if not escoria.object_manager.objects.has(arguments[0]):

--- a/addons/escoria-core/game/core-scripts/esc/commands/anim_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/anim_block.gd
@@ -1,7 +1,7 @@
 # `anim_block object name [reverse]`
 #
-# Executes the animation specified in "name" on "object", 
-# while blocking. The next command in the event will be executed when the animation 
+# Executes the animation specified in "name" on "object",
+# while blocking. The next command in the event will be executed when the animation
 # is finished playing.
 #
 # **Parameters**
@@ -9,7 +9,7 @@
 # * *object*: Global ID of the object with the animation
 # * *name*: Name of the animation to play
 # * *reverse*: Plays the animation in reverse when true
-# 
+#
 # @ESC
 extends ESCBaseCommand
 class_name AnimBlockCommand
@@ -18,12 +18,12 @@ class_name AnimBlockCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING, TYPE_BOOL],
 		[null, null, false]
 	)
-	
-	
+
+
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):
 	if not escoria.object_manager.objects.has(arguments[0]):

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_push.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_push.gd
@@ -4,13 +4,13 @@
 #
 # **Parameters**
 #
-# - *target*: Global ID of the `ESCItem` to push the camera to. If the target 
+# - *target*: Global ID of the `ESCItem` to push the camera to. If the target
 #   has a child node called `camera_node`, its location will be used. If not,
 #   the location of the target will be used
 # - *time*: Number of seconds the transition should take (default: `1`)
 # - *type*: Transition type to use (default: `QUAD`)
 #
-# Supported transitions include the names of the values used 
+# Supported transitions include the names of the values used
 # in the "TransitionType" enum of the "Tween" type (without the "TRANS_" prefix):
 #
 # https://docs.godotengine.org/en/stable/classes/class_tween.html?highlight=tween#enumerations
@@ -25,11 +25,11 @@ class_name CameraPushCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		1, 
+		1,
 		[TYPE_STRING, [TYPE_REAL, TYPE_INT], TYPE_STRING],
 		[null, 1, "QUAD"]
 	)
-	
+
 
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):
@@ -41,7 +41,7 @@ func validate(arguments: Array):
 			]
 		)
 		return false
-	
+
 	return .validate(arguments)
 
 

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_limits.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_limits.gd
@@ -4,7 +4,7 @@
 #
 # **Parameters**
 #
-# - *camlimits_id*: Index of the camera limit in the `camera limits` 
+# - *camlimits_id*: Index of the camera limit in the `camera limits`
 #   list of the current `ESCRoom`
 #
 # For more details see: https://docs.escoria-framework.org/camera
@@ -17,12 +17,12 @@ class_name CameraSetLimitsCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		1, 
+		1,
 		[TYPE_INT],
 		[null]
 	)
-	
-	
+
+
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):
 	if escoria.main.current_scene.camera_limits.size() < arguments[0]:
@@ -36,7 +36,7 @@ func validate(arguments: Array):
 			]
 		)
 		return false
-	
+
 	return .validate(arguments)
 
 

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_pos.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_pos.gd
@@ -18,7 +18,7 @@ class_name CameraSetPosCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		3, 
+		3,
 		[[TYPE_REAL, TYPE_INT], TYPE_INT, TYPE_INT],
 		[null, null, null]
 	)
@@ -28,7 +28,7 @@ func configure() -> ESCCommandArgumentDescriptor:
 func run(command_params: Array) -> int:
 	(escoria.object_manager.get_object(escoria.object_manager.CAMERA).node as ESCCamera)\
 			.set_target(
-				Vector2(command_params[1], command_params[2]), 
+				Vector2(command_params[1], command_params[2]),
 				command_params[0]
 			)
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_target.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_target.gd
@@ -17,11 +17,11 @@ class_name CameraSetTargetCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[[TYPE_REAL, TYPE_INT], TYPE_STRING],
 		[null, null]
 	)
-	
+
 
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):
@@ -33,7 +33,7 @@ func validate(arguments: Array):
 			]
 		)
 		return false
-	
+
 	return .validate(arguments)
 
 

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom.gd
@@ -1,7 +1,7 @@
 # `camera_set_zoom magnitude [time]`
 #
-# Zooms the camera in/out to the desired `magnitude`. Values larger than 1 zoom 
-# the camera out while smaller values zoom in, relative to the default value 
+# Zooms the camera in/out to the desired `magnitude`. Values larger than 1 zoom
+# the camera out while smaller values zoom in, relative to the default value
 # of 1.
 #
 # **Parameters**
@@ -20,7 +20,7 @@ class_name CameraSetZoomCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		1, 
+		1,
 		[[TYPE_REAL, TYPE_INT], [TYPE_REAL, TYPE_INT]],
 		[null, 0.0]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom_height.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom_height.gd
@@ -18,7 +18,7 @@ class_name CameraSetZoomHeightCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		1, 
+		1,
 		[TYPE_INT, [TYPE_INT, TYPE_REAL]],
 		[null, 0.0]
 	)
@@ -34,7 +34,7 @@ func validate(arguments: Array):
 			]
 		)
 		return false
-	
+
 	return .validate(arguments)
 
 

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_shift.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_shift.gd
@@ -10,7 +10,7 @@
 #   meaning the zoom should happen instantly (default: `1`)
 # - *type*: Transition type to use (default: `QUAD`)
 #
-# Supported transitions include the names of the values used 
+# Supported transitions include the names of the values used
 # in the "TransitionType" enum of the "Tween" type (without the "TRANS_" prefix):
 #
 # https://docs.godotengine.org/en/stable/classes/class_tween.html?highlight=tween#enumerations
@@ -25,16 +25,16 @@ class_name CameraShiftCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[
-			[TYPE_INT, TYPE_REAL], 
-			[TYPE_INT, TYPE_REAL], 
-			[TYPE_INT, TYPE_REAL], 
+			[TYPE_INT, TYPE_REAL],
+			[TYPE_INT, TYPE_REAL],
+			[TYPE_INT, TYPE_REAL],
 			TYPE_STRING
 		],
 		[null, null, 1, "QUAD"]
 	)
-	
+
 
 # Run the command
 func run(command_params: Array) -> int:

--- a/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
@@ -5,7 +5,7 @@
 # **Parameters**
 #
 # - *path*: Path of the new scene
-# - *enable_automatic_transition*: Automatically transition to the new scene 
+# - *enable_automatic_transition*: Automatically transition to the new scene
 #   (default: `true`)
 # - *run_events*: Run the standard ESC events of the new scene (default: `true`)
 #
@@ -17,17 +17,17 @@ class_name ChangeSceneCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		1, 
+		1,
 		[TYPE_STRING, TYPE_BOOL, TYPE_BOOL],
 		[null, true, true]
 	)
-	
-	
+
+
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array) -> bool:
 	if not ResourceLoader.exists(arguments[0]):
 		escoria.logger.report_errors(
-			"change_scene: Invalid scene", 
+			"change_scene: Invalid scene",
 			["Scene %s was not found" % arguments[0]]
 		)
 		return false
@@ -35,7 +35,7 @@ func validate(arguments: Array) -> bool:
 		escoria.project_settings_manager.get_setting(escoria.project_settings_manager.GAME_SCENE)
 	):
 		escoria.logger.report_errors(
-			"change_scene: Game scene not found", 
+			"change_scene: Game scene not found",
 			[
 				"The path set in 'ui/game_scene' was not found: %s" % \
 						escoria.project_settings_manager.get_setting(
@@ -54,7 +54,7 @@ func run(command_params: Array) -> int:
 		command_params[0],	# scene file
 		command_params[1]	# enable_automatic_transition
 	])
-	
+
 	escoria.room_manager.change_scene(command_params[0], command_params[1])
-		
+
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc/commands/custom.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/custom.gd
@@ -1,5 +1,5 @@
 # `custom object node func_name [params]`
-# 
+#
 # Calls the given Godot function on a (child) node of a registered `ESCitem`.
 #
 # **Parameters**
@@ -18,7 +18,7 @@ class_name CustomCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		3, 
+		3,
 		[TYPE_STRING, TYPE_STRING, TYPE_STRING, TYPE_ARRAY],
 		[null, null, null, []]
 	)
@@ -74,7 +74,7 @@ func run(command_params: Array) -> int:
 		command_params[0]
 	)
 	object.node.get_node(command_params[1]).call(
-		command_params[2], 
+		command_params[2],
 		command_params[3]
 	)
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc/commands/debug.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/debug.gd
@@ -14,11 +14,11 @@ class_name DebugCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		1, 
+		1,
 		[TYPE_STRING],
 		[""]
 	)
-	
+
 
 # Run the command
 func run(command_params: Array) -> int:

--- a/addons/escoria-core/game/core-scripts/esc/commands/dec_global.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/dec_global.gd
@@ -1,5 +1,5 @@
 # `dec_global name value`
-# 
+#
 # Subtract the given value from the specified global.
 #
 # **Parameters**
@@ -15,7 +15,7 @@ class_name DecGlobalCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_INT],
 		[null, 0]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/enable_terrain.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/enable_terrain.gd
@@ -15,7 +15,7 @@ class_name EnableTerrainCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		1, 
+		1,
 		[TYPE_STRING],
 		[null]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/hide_menu.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/hide_menu.gd
@@ -1,6 +1,6 @@
 # `hide_menu menu_type [enable_automatic_transition]`
 #
-# Hides either the main menu or the pause menu. 
+# Hides either the main menu or the pause menu.
 #
 # **Parameters**
 #
@@ -15,7 +15,7 @@ class_name HideMenuCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		0, 
+		0,
 		[TYPE_STRING, TYPE_BOOL],
 		["main", false]
 	)
@@ -40,28 +40,28 @@ func run(command_params: Array) -> int:
 	if command_params[1]:
 		# Transition out from menu
 		transition_id = escoria.main.scene_transition.transition(
-			"", 
+			"",
 			ESCTransitionPlayer.TRANSITION_MODE.OUT
 		)
 		while yield(
-			escoria.main.scene_transition, 
+			escoria.main.scene_transition,
 			"transition_done"
 		) != transition_id:
 			pass
-		
+
 	if command_params[0] == "main":
 		escoria.game_scene.hide_main_menu()
 	elif command_params[0] == "pause":
 		escoria.game_scene.unpause_game()
-		
+
 	if command_params[1] and escoria.main.current_scene != null:
 		transition_id = escoria.main.scene_transition.transition()
-	
+
 	if command_params[1] and escoria.main.current_scene != null:
 		while yield(
-			escoria.main.scene_transition, 
+			escoria.main.scene_transition,
 			"transition_done"
 		) != transition_id:
 			pass
-	
+
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc/commands/inc_global.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/inc_global.gd
@@ -1,5 +1,5 @@
 # `inc_global name value`
-# 
+#
 # Adds the given value to the specified global.
 #
 # **Parameters**
@@ -15,7 +15,7 @@ class_name IncGlobalCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_INT],
 		[null, 0]
 	)
@@ -45,7 +45,7 @@ func validate(arguments: Array):
 # Run the command
 func run(command_params: Array) -> int:
 	escoria.globals_manager.set_global(
-		command_params[0], 
+		command_params[0],
 		escoria.globals_manager.get_global(command_params[0]) +\
 				command_params[1]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/inventory_add.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/inventory_add.gd
@@ -14,7 +14,7 @@ class_name InventoryAddCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		1, 
+		1,
 		[TYPE_STRING],
 		[null]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/inventory_remove.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/inventory_remove.gd
@@ -14,7 +14,7 @@ class_name InventoryRemoveCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		1, 
+		1,
 		[TYPE_STRING],
 		[null]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/play_snd.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/play_snd.gd
@@ -1,5 +1,5 @@
 # `play_snd file [player]`
-# 
+#
 # Plays the specified sound without blocking the event.
 #
 # **Parameters**
@@ -17,11 +17,11 @@ class_name PlaySndCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING],
 		[null, "_sound"]
 	)
-	
+
 
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):

--- a/addons/escoria-core/game/core-scripts/esc/commands/queue_event.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/queue_event.gd
@@ -19,11 +19,11 @@ class_name QueueEventCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING, TYPE_STRING, TYPE_BOOL],
 		[null, null, "_front", false]
 	)
-	
+
 
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):
@@ -72,9 +72,9 @@ func run(arguments: Array) -> int:
 		arguments[0]
 	).node
 	var esc_script = escoria.esc_compiler.load_esc_file(node.esc_script)
-	
+
 	return escoria.event_manager.queue_event_from_esc(
-		esc_script, 
+		esc_script,
 		arguments[1], # event name
 		arguments[2], # channel name
 		arguments[3]  # whether to block

--- a/addons/escoria-core/game/core-scripts/esc/commands/queue_resource.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/queue_resource.gd
@@ -3,7 +3,7 @@
 # Queues the loading of the given resource into the resource cache.
 #
 # **Parameters**
-# 
+#
 # - *path*: Path of the resource to cache
 # - *front_of_queue*: Whether to put the resource at the front of the
 #   queue in order to load it as soon as possible (default: `false`)
@@ -16,7 +16,7 @@ class_name QueueResourceCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		1, 
+		1,
 		[],
 		[null, false]
 	)
@@ -26,7 +26,7 @@ func configure() -> ESCCommandArgumentDescriptor:
 func validate(arguments: Array) -> bool:
 	if not ResourceLoader.exists(arguments[0]):
 		escoria.logger.report_errors(
-			"queue_resource: Invalid resource", 
+			"queue_resource: Invalid resource",
 			["Resource %s was not found" % arguments[0]]
 		)
 		return false

--- a/addons/escoria-core/game/core-scripts/esc/commands/rand_global.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/rand_global.gd
@@ -15,7 +15,7 @@ class_name RandGlobalCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_INT],
 		[null, 1]
 	)
@@ -47,7 +47,7 @@ func run(command_params: Array) -> int:
 	randomize()
 	var rnd = randi() % command_params[1]
 	escoria.globals_manager.set_global(
-		command_params[0], 
+		command_params[0],
 		rnd
 	)
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc/commands/repeat.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/repeat.gd
@@ -1,8 +1,8 @@
 # `repeat`
 #
-# Restarts the execution of the current scope at the start. A scope can be a 
+# Restarts the execution of the current scope at the start. A scope can be a
 # group or an event.
-# 
+#
 # @ESC
 extends ESCBaseCommand
 class_name RepeatCommand
@@ -11,7 +11,7 @@ class_name RepeatCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		0, 
+		0,
 		[],
 		[]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/say.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/say.gd
@@ -1,18 +1,18 @@
 # `say player text [type]`
 #
-# Displays the specified string as dialog spoken by the player. Blocks execution 
+# Displays the specified string as dialog spoken by the player. Blocks execution
 # until the dialog has finished playing.
 #
 # **Parameters**
 #
 # - *player*: Global ID of the `ESCPlayer` or `ESCItem` object that is active
 # - *text*: Text to display
-# - *type*: Dialog type to use. One of `floating` or `avatar` 
+# - *type*: Dialog type to use. One of `floating` or `avatar`
 #   (default: the value set in the setting "Escoria/UI/Default Dialog Type")
 #
 # The text supports translation keys by prepending the key followed by
 # a colon (`:`) to the text.
-# 
+#
 # Example: `say player ROOM1_PICTURE:"Picture's looking good."`
 #
 # @ESC
@@ -23,11 +23,11 @@ class_name SayCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING, TYPE_STRING],
 		[
-			null, 
-			null, 
+			null,
+			null,
 			""
 		],
 		[
@@ -36,8 +36,8 @@ func configure() -> ESCCommandArgumentDescriptor:
 			true
 		]
 	)
-	
-	
+
+
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):
 	if not escoria.object_manager.objects.has(arguments[0]):
@@ -51,35 +51,35 @@ func validate(arguments: Array):
 	if ProjectSettings.get_setting("escoria/ui/default_dialog_type") == "" \
 			and arguments[2] == "":
 		escoria.logger.report_errors(
-			"say()", 
+			"say()",
 			[
-				"Project setting 'escoria/ui/default_dialog_type' is not set.", 
+				"Project setting 'escoria/ui/default_dialog_type' is not set.",
 				"Please set a default dialog type."
 			]
 		)
 	return .validate(arguments)
-	
+
 
 # Run the command
 func run(command_params: Array) -> int:
-	
+
 	var dict: Dictionary
-	
+
 	escoria.current_state = escoria.GAME_STATE.DIALOG
-	
+
 	if !escoria.dialog_player:
 		escoria.logger.report_errors(
-			"No dialog player registered", 
+			"No dialog player registered",
 			[
 				"No dialog player was registered and the say command was" +
 						"encountered."
 			]
 		)
 		return ESCExecution.RC_ERROR
-	
+
 	escoria.dialog_player.say(
-		command_params[0], 
-		command_params[2], 
+		command_params[0],
+		command_params[2],
 		command_params[1]
 	)
 	yield(escoria.dialog_player, "say_finished")

--- a/addons/escoria-core/game/core-scripts/esc/commands/sched_event.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/sched_event.gd
@@ -1,9 +1,9 @@
 # `sched_event time object event`
-# 
+#
 # Schedules the execution to run at a later time.
 #
 # If another event is already running when the scheduled
-# event is to start, execution of the scheduled event 
+# event is to start, execution of the scheduled event
 # begins when the already-running event ends.
 #
 # **Parameters**
@@ -20,7 +20,7 @@ class_name SchedEventCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		3, 
+		3,
 		[TYPE_INT, TYPE_STRING, TYPE_STRING],
 		[null, null, null]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_active.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_active.gd
@@ -1,6 +1,6 @@
 # `set_active object active`
-# 
-# Changes the "active" state of the object. `active` can be `true` or `false`. 
+#
+# Changes the "active" state of the object. `active` can be `true` or `false`.
 # Inactive objects are invisible in the room.
 #
 # **Parameters**
@@ -16,11 +16,11 @@ class_name SetActiveCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_BOOL],
 		[null, null]
 	)
-	
+
 
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_angle.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_angle.gd
@@ -7,7 +7,7 @@
 # - *object*: Global ID of the object to turn
 # - *degrees*: Number of degrees by which `object` is to be turned
 # - *wait*: Number of seconds to wait for each animation occurring between the
-#   current angle of `object` and the angle specified. A value of `0` will 
+#   current angle of `object` and the angle specified. A value of `0` will
 #   complete the turn immediately (default: `0`)
 #
 # @ESC
@@ -18,11 +18,11 @@ class_name SetAngleCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_INT, TYPE_REAL],
 		[null, null, 0.0]
 	)
-	
+
 
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):
@@ -44,8 +44,8 @@ func run(command_params: Array) -> int:
 	# Since the ESC command already gives the right angle, we add 90.
 	escoria.object_manager.get_object(command_params[0]).node\
 			.set_angle(
-				wrapi(int(command_params[1]) + 90, 0, 360), 
+				wrapi(int(command_params[1]) + 90, 0, 360),
 				command_params[2]
 			)
 	return ESCExecution.RC_OK
-	
+

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_animations.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_animations.gd
@@ -15,7 +15,7 @@ class_name SetAnimationsCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING],
 		[null, null]
 	)
@@ -40,7 +40,7 @@ func validate(arguments: Array):
 		)
 		return false
 	return .validate(arguments)
-	
+
 
 # Run the command
 func run(command_params: Array) -> int:
@@ -64,4 +64,4 @@ func run(command_params: Array) -> int:
 		true
 	)
 	return ESCExecution.RC_OK
-	
+

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_global.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_global.gd
@@ -15,7 +15,7 @@ class_name SetGlobalCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, [TYPE_INT, TYPE_BOOL, TYPE_STRING]],
 		[null, null]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_globals.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_globals.gd
@@ -1,7 +1,7 @@
 # `set_globals pattern value`
 #
 # Changes the value of multiple globals using a wildcard pattern, where `*`
-# matches zero or more arbitrary characters and `?` matches any single 
+# matches zero or more arbitrary characters and `?` matches any single
 # character except a period (".").
 #
 # **Parameters**
@@ -17,7 +17,7 @@ class_name SetGlobalsCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, [TYPE_BOOL, TYPE_STRING, TYPE_INT]],
 		[null, null]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_gui_visible.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_gui_visible.gd
@@ -14,7 +14,7 @@ class_name SetGuiVisibleCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		1, 
+		1,
 		[TYPE_BOOL],
 		[null]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_interactive.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_interactive.gd
@@ -15,11 +15,11 @@ class_name SetInteractiveCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_BOOL],
 		[null, null]
 	)
-	
+
 
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_speed.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_speed.gd
@@ -15,7 +15,7 @@ class_name SetSpeedCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_INT],
 		[null, null]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/set_state.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_state.gd
@@ -2,10 +2,10 @@
 #
 # Changes the state of `object` to the one specified.
 #
-# If the specified object's associated animation player has an animation 
+# If the specified object's associated animation player has an animation
 # with the same name, that that animation is also played.
 #
-# Can be used to change the appearance of an item or player 
+# Can be used to change the appearance of an item or player
 # character. See https://docs.escoria-framework.org/states for details.
 #
 # **Parameters**
@@ -22,11 +22,11 @@ class_name SetStateCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING, TYPE_BOOL],
 		[null, null, false]
 	)
-	
+
 
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):

--- a/addons/escoria-core/game/core-scripts/esc/commands/show_menu.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/show_menu.gd
@@ -1,6 +1,6 @@
 # `show_menu menu_type [enable_automatic_transition]`
 #
-# Shows either the main menu or the pause menu. 
+# Shows either the main menu or the pause menu.
 #
 # **Parameters**
 #
@@ -15,7 +15,7 @@ class_name ShowMenuCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		0, 
+		0,
 		[TYPE_STRING, TYPE_BOOL],
 		["main", false]
 	)
@@ -38,37 +38,37 @@ func validate(arguments: Array):
 func run(command_params: Array) -> int:
 	if not escoria.game_scene.is_inside_tree():
 		escoria.add_child(escoria.game_scene)
-	
+
 	if command_params[1]:
 		# Transition out from current scene
 		var transition_id = escoria.main.scene_transition.transition(
-			"", 
+			"",
 			ESCTransitionPlayer.TRANSITION_MODE.OUT
 		)
 		while yield(
-			escoria.main.scene_transition, 
+			escoria.main.scene_transition,
 			"transition_done"
 		) != transition_id:
 			pass
-			
+
 		if command_params[0] == "main":
 			escoria.game_scene.show_main_menu()
 		elif command_params[0] == "pause":
 			escoria.game_scene.pause_game()
-		
+
 		# Transition in to menu
 		transition_id = escoria.main.scene_transition.transition()
-			
+
 		while yield(
-			escoria.main.scene_transition, 
+			escoria.main.scene_transition,
 			"transition_done"
 		) != transition_id:
 			pass
-	
+
 	else:
 		if command_params[0] == "main":
 			escoria.game_scene.show_main_menu()
 		elif command_params[0] == "pause":
 			escoria.game_scene.pause_game()
-	
+
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc/commands/slide.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/slide.gd
@@ -1,7 +1,7 @@
 # `slide object target [speed]`
 #
 # Moves `object` towards the position of `target`. This command is
-# non-blocking. 
+# non-blocking.
 #
 # - *object*: Global ID of the object to move
 # - *target*: Global ID of the target object
@@ -22,7 +22,7 @@ var _tweens: Dictionary
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING, TYPE_INT],
 		[null, null, -1]
 	)
@@ -37,7 +37,7 @@ func validate(arguments: Array):
 				"Object with global id %s not found" % arguments[0]
 			]
 		)
-		return false	
+		return false
 	if not escoria.object_manager.objects.has(arguments[1]):
 		escoria.logger.report_errors(
 			"slide: invalid second object",
@@ -55,30 +55,30 @@ func validate(arguments: Array):
 #
 # - source: The item to slide
 # - destination: The destination item to slide to
-# - speed: The speed at which to slide (will default to the 
+# - speed: The speed at which to slide (will default to the
 #
 # **Returns** The generated (and started) tween
 func _slide_object(
-	source: ESCObject, 
-	destination: ESCObject, 
+	source: ESCObject,
+	destination: ESCObject,
 	speed: int = -1
 ) -> Tween:
 	if speed == -1:
 		speed = source.node.speed
-		
+
 	if _tweens.has(source.global_id):
 		var tween = (_tweens.get(source.global_id) as Tween)
 		tween.stop_all()
 		if (escoria.main as Node).has_node(tween.name):
 			(escoria.main as Node).remove_child(tween)
-	
+
 	var tween = Tween.new()
 	(escoria.main as Node).add_child(tween)
-	
+
 	var duration = source.node.position.distance_to(
 		destination.node.position
 	) / speed
-	
+
 	tween.interpolate_property(
 		source.node,
 		"global_position",
@@ -86,13 +86,13 @@ func _slide_object(
 		destination.node.global_position,
 		duration
 	)
-	
+
 	tween.start()
-	
+
 	_tweens[source.global_id] = tween
-	
+
 	return tween
-	
+
 
 
 # Run the command

--- a/addons/escoria-core/game/core-scripts/esc/commands/slide_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/slide_block.gd
@@ -1,7 +1,7 @@
 # `slide_block object target [speed]`
 #
 # Moves `object` towards the position of `target`. This command is
-# blocking. 
+# blocking.
 #
 # - *object*: Global ID of the object to move
 # - *target*: Global ID of the target object

--- a/addons/escoria-core/game/core-scripts/esc/commands/spawn.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/spawn.gd
@@ -18,7 +18,7 @@ class_name SpawnCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING, TYPE_BOOL, TYPE_STRING],
 		[null, null, true, null]
 	)
@@ -57,7 +57,7 @@ func validate(arguments: Array):
 # Run the command
 func run(command_params: Array) -> int:
 	var res_scene = escoria.resource_cache.get_resource(command_params[1])
-		
+
 	# Load room scene
 	var scene = res_scene.instance()
 	if scene:
@@ -66,7 +66,7 @@ func run(command_params: Array) -> int:
 			var obj = escoria.object_manager.get_object(command_params[3])
 			scene.set_position(obj.get_global_position())
 		escoria.inputs_manager.hotspot_focused = ""
-		
+
 		escoria.object_manager.register_object(
 			ESCObject.new(
 				command_params[0],
@@ -74,13 +74,13 @@ func run(command_params: Array) -> int:
 			),
 			true
 		)
-		
+
 		escoria.object_manager.get_object(command_params[0]).active = \
 			command_params[2]
-		
+
 	else:
 		escoria.logger.report_errors(
-			"spawn: Invalid scene", 
+			"spawn: Invalid scene",
 			[
 				"Failed loading scene %s" % command_params[1]
 			]

--- a/addons/escoria-core/game/core-scripts/esc/commands/stop.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/stop.gd
@@ -1,7 +1,7 @@
 # `stop`
 #
 # Stops the current event's execution.
-# 
+#
 # @ESC
 extends ESCBaseCommand
 class_name StopCommand
@@ -10,7 +10,7 @@ class_name StopCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		0, 
+		0,
 		[],
 		[]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/stop_snd.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/stop_snd.gd
@@ -1,5 +1,5 @@
 # `stop_snd [player]`
-# 
+#
 # Stops the given sound player's stream.
 #
 # **Parameters**
@@ -16,11 +16,11 @@ class_name StopSndCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		0, 
+		0,
 		[TYPE_STRING],
 		["_music"]
 	)
-	
+
 
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):
@@ -31,7 +31,7 @@ func validate(arguments: Array):
 		)
 		return false
 	return .validate(arguments)
-	
+
 
 # Run the command
 func run(command_params: Array) -> int:

--- a/addons/escoria-core/game/core-scripts/esc/commands/teleport.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/teleport.gd
@@ -15,12 +15,12 @@ class_name TeleportCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING],
 		[null, null]
 	)
-	
-	
+
+
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):
 	if not escoria.object_manager.objects.has(arguments[0]):
@@ -30,7 +30,7 @@ func validate(arguments: Array):
 				"Object with global id %s not found" % arguments[0]
 			]
 		)
-		return false	
+		return false
 	if not escoria.object_manager.objects.has(arguments[1]):
 		escoria.logger.report_errors(
 			"teleport: invalid second object",

--- a/addons/escoria-core/game/core-scripts/esc/commands/teleport_pos.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/teleport_pos.gd
@@ -16,12 +16,12 @@ class_name TeleportPosCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_INT, TYPE_INT],
 		[null, null, null]
 	)
-	
-	
+
+
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):
 	if not escoria.object_manager.objects.has(arguments[0]):

--- a/addons/escoria-core/game/core-scripts/esc/commands/transition.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/transition.gd
@@ -1,14 +1,14 @@
 # `transition transition_name mode [delay]`
 #
 # Performs a transition into or out of a room programmatically.
-# 
+#
 # **Parameters**
 #
 # - *transition_name*: Name of the transition shader from one of the transition
 #   directories
 # - *mode*: Set to `in` to transition into or `out` to transition out of the room
 # - *delay*: Delay in seconds before starting the transition (default: `1`)
-# 
+#
 # @ESC
 extends ESCBaseCommand
 class_name TransitionCommand
@@ -17,12 +17,12 @@ class_name TransitionCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING, TYPE_REAL],
 		[null, null, 1.0]
 	)
-	
-	
+
+
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):
 	if not escoria.main.scene_transition.has_transition(arguments[0]):
@@ -52,13 +52,13 @@ func run(command_params: Array) -> int:
 				else ESCTransitionPlayer.TRANSITION_MODE.IN,
 		command_params[2]
 	)
-	escoria.logger.debug("Starting transition #%s [%s, %s]" 
+	escoria.logger.debug("Starting transition #%s [%s, %s]"
 		% [transition_id, command_params[0], command_params[1]])
 	while yield(
-		escoria.main.scene_transition, 
+		escoria.main.scene_transition,
 		"transition_done"
 	) != transition_id:
 		pass
-	escoria.logger.debug("Ending transition #%s [%s, %s]" 
+	escoria.logger.debug("Ending transition #%s [%s, %s]"
 		% [transition_id, command_params[0], command_params[1]])
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc/commands/turn_to.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/turn_to.gd
@@ -1,14 +1,14 @@
 # `turn_to object object_to_face [wait]`
-# 
-# Turns `object` to face another object. 
+#
+# Turns `object` to face another object.
 #
 # **Parameters**
 #
 # - *object*: Global ID of the object to be turned
 # - *object_to_face*: Global ID of the object to turn towards
-# - *wait*: Length of time to wait in seconds for each intermediate angle. 
+# - *wait*: Length of time to wait in seconds for each intermediate angle.
 #   If set to 0, the turnaround is immediate (default: `0`)
-##  
+##
 # @ESC
 extends ESCBaseCommand
 class_name TurnToCommand
@@ -17,11 +17,11 @@ class_name TurnToCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING, TYPE_REAL],
 		[null, null, 0.0]
 	)
-	
+
 
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array):

--- a/addons/escoria-core/game/core-scripts/esc/commands/wait.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/wait.gd
@@ -14,7 +14,7 @@ class_name WaitCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		1, 
+		1,
 		[[TYPE_INT, TYPE_REAL]],
 		[null]
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/walk.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/walk.gd
@@ -8,7 +8,7 @@
 # - *object*: Global ID of the object to move
 # - *target*: Global ID of the target object
 # - *speed*: Walking speed to use (default: `object`'s default speed)
-# 
+#
 # @ESC
 extends ESCBaseCommand
 class_name WalkCommand
@@ -17,7 +17,7 @@ class_name WalkCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING, TYPE_INT],
 		[null, null, null]
 	)
@@ -32,7 +32,7 @@ func validate(arguments: Array):
 				"Object with global id %s not found" % arguments[0]
 			]
 		)
-		return false	
+		return false
 	if not escoria.object_manager.objects.has(arguments[1]):
 		escoria.logger.report_errors(
 			"walk: invalid second object",
@@ -47,7 +47,7 @@ func validate(arguments: Array):
 # Run the command
 func run(command_params: Array) -> int:
 	escoria.action_manager.do(
-		escoria.action_manager.ACTION.BACKGROUND_CLICK, 
+		escoria.action_manager.ACTION.BACKGROUND_CLICK,
 		command_params
 	)
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc/commands/walk_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/walk_block.gd
@@ -1,6 +1,6 @@
 # `walk_block object target [speed]`
 #
-# Moves the specified `ESCPlayer` or movable `ESCItem` to `target` 
+# Moves the specified `ESCPlayer` or movable `ESCItem` to `target`
 # while playing `object`'s walking animation. This command is blocking.
 #
 # **Parameters**
@@ -8,7 +8,7 @@
 # - *object*: Global ID of the object to move
 # - *target*: Global ID of the target object
 # - *speed*: Walking speed to use (default: `object`'s default speed)
-# 
+#
 # @ESC
 extends ESCBaseCommand
 class_name WalkBlockCommand
@@ -17,7 +17,7 @@ class_name WalkBlockCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		2, 
+		2,
 		[TYPE_STRING, TYPE_STRING, TYPE_INT],
 		[null, null, null]
 	)
@@ -32,7 +32,7 @@ func validate(arguments: Array):
 				"Object with global id %s not found" % arguments[0]
 			]
 		)
-		return false	
+		return false
 	if not escoria.object_manager.objects.has(arguments[1]):
 		escoria.logger.report_errors(
 			"walk_block: invalid second object",
@@ -47,11 +47,11 @@ func validate(arguments: Array):
 # Run the command
 func run(command_params: Array) -> int:
 	escoria.action_manager.do(
-		escoria.action_manager.ACTION.BACKGROUND_CLICK, 
+		escoria.action_manager.ACTION.BACKGROUND_CLICK,
 		command_params
 	)
 	yield(
-		(escoria.object_manager.objects[command_params[0]].node as ESCItem), 
+		(escoria.object_manager.objects[command_params[0]].node as ESCItem),
 		"arrived"
 	)
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc/commands/walk_to_pos.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/walk_to_pos.gd
@@ -1,7 +1,7 @@
 # `walk_to_pos object x y`
 #
-# Moves the specified `ESCPlayer` or movable `ESCItem` to the target 
-# position while playing `object`'s walking animation. 
+# Moves the specified `ESCPlayer` or movable `ESCItem` to the target
+# position while playing `object`'s walking animation.
 # This command is non-blocking.
 #
 # **Parameters**
@@ -9,7 +9,7 @@
 # - *object*: Global ID of the object to move
 # - *x*: X-coordinate of target position
 # - *y*: Y-coordinate of target position
-# 
+#
 # @ESC
 extends ESCBaseCommand
 class_name WalkToPosCommand
@@ -18,7 +18,7 @@ class_name WalkToPosCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		3, 
+		3,
 		[TYPE_STRING, TYPE_INT, TYPE_INT],
 		[null, null, null]
 	)
@@ -33,7 +33,7 @@ func validate(arguments: Array):
 				"Object with global id %s not found" % arguments[0]
 			]
 		)
-		return false	
+		return false
 	return .validate(arguments)
 
 

--- a/addons/escoria-core/game/core-scripts/esc/commands/walk_to_pos_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/walk_to_pos_block.gd
@@ -1,7 +1,7 @@
 # `walk_to_pos_block object x y`
 #
-# Moves the specified `ESCPlayer` or movable `ESCItem` to the target 
-# position while playing `object`'s walking animation. 
+# Moves the specified `ESCPlayer` or movable `ESCItem` to the target
+# position while playing `object`'s walking animation.
 # This command is blocking.
 #
 # **Parameters**
@@ -9,7 +9,7 @@
 # - *object*: Global ID of the object to move
 # - *x*: X-coordinate of target position
 # - *y*: Y-coordinate of target position
-# 
+#
 # @ESC
 extends ESCBaseCommand
 class_name WalkToPosBlockCommand
@@ -18,7 +18,7 @@ class_name WalkToPosBlockCommand
 # Return the descriptor of the arguments of this command
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
-		3, 
+		3,
 		[TYPE_STRING, TYPE_INT, TYPE_INT],
 		[null, null, null]
 	)
@@ -33,7 +33,7 @@ func validate(arguments: Array):
 				"Object with global id %s not found" % arguments[0]
 			]
 		)
-		return false	
+		return false
 	return .validate(arguments)
 
 
@@ -44,7 +44,7 @@ func run(command_params: Array) -> int:
 		Vector2(command_params[1], command_params[2])
 	])
 	yield(
-		(escoria.object_manager.objects[command_params[0]].node as ESCItem), 
+		(escoria.object_manager.objects[command_params[0]].node as ESCItem),
 		"arrived"
 	)
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -75,7 +75,7 @@ var action_state = ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM \
 #
 # - action: type of the action to run
 # - params: Parameters for the action
-# - can_interrupt: if true, this command will interrupt any ongoing event 
+# - can_interrupt: if true, this command will interrupt any ongoing event
 # before it is finished
 func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 	if escoria.current_state == escoria.GAME_STATE.DEFAULT:
@@ -83,13 +83,13 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 			ACTION.BACKGROUND_CLICK:
 				if can_interrupt:
 					escoria.event_manager.interrupt_running_event()
-					
+
 				self.clear_current_action()
-				
+
 				var walk_fast = false
 				if params.size() > 2:
 					walk_fast = true if params[2] else false
-					
+
 				# Check moving object.
 				if not escoria.object_manager.has(params[0]):
 					escoria.logger.report_errors(
@@ -100,10 +100,10 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 						]
 					)
 					return
-				
+
 				var moving_obj = escoria.object_manager.get_object(params[0])
 				var target
-				
+
 				if params[1] is String:
 					if not escoria.object_manager.has(params[1]):
 						escoria.logger.report_errors(
@@ -114,39 +114,39 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 							]
 						)
 						return
-						
+
 					target = escoria.object_manager.get_object(params[1])
 				elif params[1] is Vector2:
 					target = params[1]
-				
+
 				self.perform_walk(moving_obj, target, walk_fast)
-						
+
 			ACTION.ITEM_LEFT_CLICK:
 				if params[0] is String:
 					escoria.logger.info(
-						"esc_action_manager.do(): item_left_click on item ", 
+						"esc_action_manager.do(): item_left_click on item ",
 						[params[0]]
 					)
-					
+
 					if can_interrupt:
 						escoria.event_manager.interrupt_running_event()
-					
+
 					var item = escoria.object_manager.get_object(params[0])
 					self.perform_inputevent_on_object(item, params[1])
-					
+
 			ACTION.ITEM_RIGHT_CLICK:
 				if params[0] is String:
 					escoria.logger.info(
-						"esc_action_manager.do(): item_right_click on item ", 
+						"esc_action_manager.do(): item_right_click on item ",
 						[params[0]]
 					)
-					
+
 					if can_interrupt:
 						escoria.event_manager.interrupt_running_event()
-						
+
 					var item = escoria.object_manager.get_object(params[0])
 					self.perform_inputevent_on_object(item, params[1], true)
-			
+
 			ACTION.TRIGGER_IN:
 				var trigger_id = params[0]
 				var object_id = params[1]
@@ -160,7 +160,7 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 						trigger_in_verb
 					]
 				)
-			
+
 			ACTION.TRIGGER_OUT:
 				var trigger_id = params[0]
 				var object_id = params[1]
@@ -174,7 +174,7 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 						trigger_out_verb
 					]
 				)
-			
+
 			_:
 				escoria.logger.report_warnings("esc_action_manager.gd:do()",
 					["Action received:", action, "with params ", params])
@@ -198,14 +198,14 @@ func set_action_input_state(p_state):
 func set_current_action(action: String):
 	if action != current_action:
 		clear_current_tool()
-		
+
 	current_action = action
-	
+
 	if action_state == ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM:
 		set_action_input_state(ACTION_INPUT_STATE.AWAITING_ITEM)
 	elif action_state == ACTION_INPUT_STATE.AWAITING_VERB:
 		set_action_input_state(ACTION_INPUT_STATE.AWAITING_VERB_CONFIRM)
-	
+
 	emit_signal("action_changed")
 
 
@@ -235,12 +235,12 @@ func clear_current_tool():
 # - target: Target ESC object
 # - combine_with: ESC object to combine with
 func _activate(
-	action: String, 
-	target: ESCObject, 
+	action: String,
+	target: ESCObject,
 	combine_with: ESCObject = null
 ) -> int:
 	escoria.logger.info("Activated action %s on %s" % [action, target])
-	
+
 	# If we're using an action which item requires to combine
 	if target.node is ESCItem\
 			and action in target.node.combine_when_selected_action_is_in:
@@ -256,14 +256,14 @@ func _activate(
 								combine_with.global_id
 							):
 						do_combine = false
-					
+
 					if do_combine:
 						var target_event = "%s %s" % [
-							action, 
+							action,
 							combine_with.global_id
 						]
 						var combine_with_event = "%s %s" % [
-							action, 
+							action,
 							target.global_id
 						]
 						if target.events.has(target_event):
@@ -271,12 +271,12 @@ func _activate(
 								target_event
 							])
 							var event_returned = yield(
-								escoria.event_manager, 
+								escoria.event_manager,
 								"event_finished"
 							)
 							while event_returned[1] != target_event:
 								event_returned = yield(
-									escoria.event_manager, 
+									escoria.event_manager,
 									"event_finished"
 								)
 							if event_returned[0] == ESCExecution.RC_OK:
@@ -291,12 +291,12 @@ func _activate(
 								]
 							)
 							var event_returned = yield(
-								escoria.event_manager, 
+								escoria.event_manager,
 								"event_finished"
 							)
 							while event_returned[1] != combine_with_event:
 								event_returned = yield(
-									escoria.event_manager, 
+									escoria.event_manager,
 									"event_finished"
 								)
 							if event_returned[0] == ESCExecution.RC_OK:
@@ -317,14 +317,14 @@ func _activate(
 									"is one-way.") % combine_with.global_id
 								)
 							escoria.logger.report_warnings(
-								"ESCActionManager.activate: Invalid action", 
+								"ESCActionManager.activate: Invalid action",
 								errors
 							)
 							emit_signal("action_finished")
 							return ESCExecution.RC_ERROR
 					else:
 						escoria.logger.report_warnings(
-							"ESCActionManager.activate: Invalid action on item", 
+							"ESCActionManager.activate: Invalid action on item",
 							[
 								(
 									"Trying to combine object %s with %s, "+
@@ -345,9 +345,9 @@ func _activate(
 						ACTION_INPUT_STATE.AWAITING_TARGET_ITEM
 					)
 					return ESCExecution.RC_OK
-			else: 
+			else:
 				escoria.logger.report_warnings(
-					"ESCActionManager.activate: Invalid action on item", 
+					"ESCActionManager.activate: Invalid action on item",
 					[
 						"Trying to run %s on object %s, " %
 						[
@@ -356,17 +356,17 @@ func _activate(
 						]
 						+ "but item must be in inventory."
 					]
-				)	
-	
+				)
+
 	if target.events.has(action):
 		escoria.event_manager.queue_event(target.events[action])
 		var event_returned = yield(
-			escoria.event_manager, 
+			escoria.event_manager,
 			"event_finished"
 		)
 		while event_returned[1] != action:
 			event_returned = yield(
-				escoria.event_manager, 
+				escoria.event_manager,
 				"event_finished"
 			)
 		if event_returned[0] == ESCExecution.RC_OK:
@@ -375,7 +375,7 @@ func _activate(
 		return event_returned[0]
 	else:
 		escoria.logger.report_warnings(
-			"ESCActionManager.activate: Invalid action", 
+			"ESCActionManager.activate: Invalid action",
 			[
 				"Event for action %s on object %s not found." % [
 					action,
@@ -397,8 +397,8 @@ func _activate(
 # - is_fast: if true, the walk is performed at fast speed (defined in the moving
 # object.
 func perform_walk(
-	moving_obj: ESCObject, 
-	destination, 
+	moving_obj: ESCObject,
+	destination,
 	is_fast: bool = false
 ):
 	# Walk to Position2D.
@@ -408,9 +408,9 @@ func perform_walk(
 			destination,
 			is_fast,
 			true
-		) 
+		)
 		moving_obj.node.walk_to(destination, walk_context)
-		
+
 	# Walk to object
 	elif destination is ESCObject:
 		if destination.node:
@@ -419,16 +419,16 @@ func perform_walk(
 				target_position = destination.node.global_position
 			else:
 				target_position = destination.node.get_interact_position()
-				
+
 			var walk_context = ESCWalkContext.new(
-				destination, 
-				target_position, 
+				destination,
+				target_position,
 				is_fast,
 				true
 			)
-			
+
 			moving_obj.node.walk_to(target_position, walk_context)
-	
+
 	else:
 		escoria.logger.report_errors(
 			"esc_controller.gd:perform_walk()",
@@ -448,20 +448,20 @@ func perform_walk(
 # - event: Input event that was received
 # - default_action: if true, run the inventory default action
 func perform_inputevent_on_object(
-	obj: ESCObject, 
-	event: InputEvent, 
+	obj: ESCObject,
+	event: InputEvent,
 	default_action: bool = false
 ):
 	"""
 	This algorithm:
-	- makes the player move to the clicked object location, if needed 
+	- makes the player move to the clicked object location, if needed
 	(if it is located in the room for example) and wait for reaching.
-	- when reached, performs an action depending on current defined action 
+	- when reached, performs an action depending on current defined action
 		* no current action defined: do nothing else
-		* current action defined: 
-			* item requires no combination: perform the current action 
+		* current action defined:
+			* item requires no combination: perform the current action
 			  on the item
-			* item requires combination: check the status of the combination 
+			* item requires combination: check the status of the combination
 			  A combination requires 3 elements to fulfill:
 				1/ a verb action
 				2/ a first "tool" (item to use)
@@ -473,25 +473,25 @@ func perform_inputevent_on_object(
 		* else do nothing, except if default_action is requested.
 		  In this case, perform the default_action on the item.
 	"""
-	
+
 	escoria.logger.info("%s left-clicked with event " % obj.global_id, [event])
-	
+
 	var event_flags = 0
 	var has_current_action: bool = false
 	if obj.events.has(current_action):
 		event_flags = obj.events[current_action].flags
 		has_current_action = true
-	
-	# Don't interact after player movement towards object 
+
+	# Don't interact after player movement towards object
 	# (because object is inactive for example)
 	var dont_interact = false
-	
-	# We need to have the new action input state BEFORE initiating the player 
+
+	# We need to have the new action input state BEFORE initiating the player
 	# move so we determine now if the object clicked will require a combination
 	# depending on the used action verb.
 	var tool_just_set = _set_tool_and_action(obj, default_action)
 	var need_combine = _check_item_needs_combine()
-	
+
 	# If the current tool was not set, this is our first item, make it tool
 	if not current_tool or (current_tool and not need_combine):
 		current_tool = obj
@@ -499,7 +499,7 @@ func perform_inputevent_on_object(
 	# make it target.
 	elif need_combine and not tool_just_set:
 		current_target = obj
-	
+
 	# Update the action input state
 	if action_state == ACTION_INPUT_STATE.AWAITING_TARGET_ITEM and current_target:
 		set_action_input_state(ACTION_INPUT_STATE.COMPLETED)
@@ -512,36 +512,36 @@ func perform_inputevent_on_object(
 	if escoria.main.current_scene.player:
 		var destination_position: Vector2 = escoria.main.current_scene.player.\
 				global_position
-		
+
 		# If clicked object not in inventory, player walks towards it
 		if not obj.node is ESCPlayer and \
 			not escoria.inventory_manager.inventory_has(obj.global_id) and \
 			(not has_current_action or not event_flags & ESCEvent.FLAG_TK):
 				var context = _walk_towards_object(
-					obj, 
-					event.position, 
+					obj,
+					event.position,
 					event.doubleclick
 				)
 				if context is GDScriptFunctionState:
 					context = yield(_walk_towards_object(
-						obj, 
-						event.position, 
+						obj,
+						event.position,
 						event.doubleclick
 					), "completed")
 				destination_position = context.target_position
 				dont_interact = context.dont_interact_on_arrival
-				
+
 		var player_global_pos = escoria.main.current_scene.player.global_position
 		var clicked_position = event.position
-	
+
 		if not player_global_pos.is_equal_approx(destination_position):
 			dont_interact = true
-	
-	# If no interaction should happen after player has arrived, leave 
+
+	# If no interaction should happen after player has arrived, leave
 	# immediately.
 	if dont_interact:
 		return
-	
+
 	# Manage exits
 	if obj.node.is_exit and current_action in ["", ACTION_WALK]:
 		_activate(ACTION_EXIT_SCENE, obj)
@@ -558,7 +558,7 @@ func perform_inputevent_on_object(
 					current_tool,
 					current_target
 				)
-					
+
 			else:
 				_activate(
 					current_action,
@@ -566,9 +566,9 @@ func perform_inputevent_on_object(
 				)
 
 
-# Prepare the "obj" object for current_action: if required, set the object as 
-# current tool. 
-# 
+# Prepare the "obj" object for current_action: if required, set the object as
+# current tool.
+#
 # #### Parameters
 #
 # - obj: the ESCObject to prepare
@@ -594,17 +594,17 @@ func _set_tool_and_action(obj: ESCObject, default_action: bool):
 	return tool_just_set
 
 
-# Checks if object requires a combination with another, according to 
+# Checks if object requires a combination with another, according to
 # currently selected action verb (or check with default action of the item).
-# 
-# *Returns* True if current action on "obj" requires a combination 
+#
+# *Returns* True if current action on "obj" requires a combination
 func _check_item_needs_combine() -> bool:
 	return current_action \
 			and current_tool \
 			and current_action in current_tool.node.combine_when_selected_action_is_in
-	
-	
-# Makes the player character walk towards the clicked item. 
+
+
+# Makes the player character walk towards the clicked item.
 # Returns the resulting walk context.
 #
 # #### Parameters
@@ -613,7 +613,7 @@ func _check_item_needs_combine() -> bool:
 # - clicked_position: the Position2D of the input click
 # - walk_fast: if true, the player will walk fast to the object
 func _walk_towards_object(
-	obj: ESCObject, 
+	obj: ESCObject,
 	clicked_position: Vector2,
 	walk_fast: bool
 ) -> ESCWalkContext:
@@ -629,32 +629,32 @@ func _walk_towards_object(
 	else:
 		destination_position = clicked_position
 		dont_interact = true
-		
-	# Create walk context 
+
+	# Create walk context
 	var walk_context = ESCWalkContext.new(
 		obj,
 		destination_position,
 		walk_fast,
 		dont_interact
 	)
-	
+
 	# Walk towards the clicked object
-	escoria.main.current_scene.player.walk_to(destination_position, 
+	escoria.main.current_scene.player.walk_to(destination_position,
 		walk_context)
-	
+
 	# Wait for the player to arrive before continuing with action.
 	var context: ESCWalkContext = yield(
 		escoria.main.current_scene.player,
 		"arrived"
 	)
 	escoria.logger.info("Context arrived: %s" % context)
-	
+
 	# Confirm that reached item was the one user clicked in the first place.
-	# Don't interact if that is not the case. 
+	# Don't interact if that is not the case.
 	if (context.target_object and context.target_object.\
 			global_id != walk_context.\
 			target_object.global_id) or \
 		(context.target_position != walk_context.target_position):
 		walk_context.dont_interact_on_arrival = true
-	
+
 	return context

--- a/addons/escoria-core/game/core-scripts/esc/esc_command_registry.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_command_registry.gd
@@ -20,12 +20,12 @@ func load_command(command_name: String) -> ESCBaseCommand:
 		if ResourceLoader.exists("%s/%s.gd" % [command_directory, command_name]):
 			registry[command_name] = load(
 				"%s/%s.gd" % [
-					command_directory.trim_suffix("/"), 
+					command_directory.trim_suffix("/"),
 					command_name
 				]
 			).new()
 			return registry[command_name]
-	
+
 	escoria.logger.report_errors(
 		"ESCCommandRegistry.load_command: Command not found",
 		[
@@ -38,7 +38,7 @@ func load_command(command_name: String) -> ESCBaseCommand:
 
 
 # Retrieve a command from the command registry
-# 
+#
 # #### Parameters
 #
 # - command_name: The name of the command

--- a/addons/escoria-core/game/core-scripts/esc/esc_compiler.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_compiler.gd
@@ -58,7 +58,7 @@ func _init():
 			"type": TYPE_STRING_ARRAY
 		}
 		ProjectSettings.add_property_info(property_info)
-	
+
 	# Compile all regex objects just once
 	_comment_regex = RegEx.new()
 	_comment_regex.compile(COMMENT_REGEX)
@@ -66,7 +66,7 @@ func _init():
 	_empty_regex.compile(EMPTY_REGEX)
 	_indent_regex = RegEx.new()
 	_indent_regex.compile(INDENT_REGEX)
-	
+
 	_event_regex = RegEx.new()
 	_event_regex.compile(ESCEvent.REGEX)
 	_command_regex = RegEx.new()
@@ -108,14 +108,14 @@ func compile(lines: Array) -> ESCScript:
 		var events = self._compile(lines)
 		for event in events:
 			script.events[event.name] = event
-			
+
 	return script
 
 
 # Compile an array of ESC script lines into an array of ESC objects
 func _compile(lines: Array) -> Array:
 	var returned = []
-	
+
 	while lines.size() > 0:
 		var line = lines.pop_front()
 		escoria.logger.trace("Parsing line %s" % line)
@@ -125,10 +125,10 @@ func _compile(lines: Array) -> Array:
 			continue
 		var indent = \
 				escoria.utils.get_re_group(
-					_indent_regex.search(line), 
+					_indent_regex.search(line),
 					INDENT_REGEX_GROUP
 				).length()
-		
+
 		if _event_regex.search(line):
 			var event = ESCEvent.new(line)
 			escoria.logger.trace("Line is the event %s" % event.name)
@@ -158,7 +158,7 @@ func _compile(lines: Array) -> Array:
 					continue
 				var next_line_indent = \
 						escoria.utils.get_re_group(
-							_indent_regex.search(next_line), 
+							_indent_regex.search(next_line),
 							INDENT_REGEX_GROUP
 						).length()
 				if next_line_indent > indent:
@@ -186,7 +186,7 @@ func _compile(lines: Array) -> Array:
 				var end_line = _dialog_end_regex.search(next_line)
 				if end_line and \
 						escoria.utils.get_re_group(
-							end_line, 
+							end_line,
 							INDENT_REGEX_GROUP
 						).length() == indent:
 					break
@@ -216,7 +216,7 @@ func _compile(lines: Array) -> Array:
 					continue
 				var next_line_indent = \
 						escoria.utils.get_re_group(
-							_indent_regex.search(next_line), 
+							_indent_regex.search(next_line),
 							INDENT_REGEX_GROUP
 						).length()
 				if next_line_indent > indent:

--- a/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
@@ -55,7 +55,7 @@ var _channels_state: Dictionary = {}
 # Make sure to stop when pausing the game
 func _ready():
 	self.pause_mode = Node.PAUSE_MODE_STOP
-	
+
 
 # Handle the events queue and scheduled events
 #
@@ -82,8 +82,8 @@ func _process(delta: float) -> void:
 				"finished", self, "_on_event_finished"
 			):
 				_running_events[channel_name].connect(
-					"finished", 
-					self, 
+					"finished",
+					self,
 					"_on_event_finished",
 					[channel_name],
 					CONNECT_ONESHOT
@@ -92,13 +92,13 @@ func _process(delta: float) -> void:
 				"interrupted", self, "_on_event_finished"
 			):
 				_running_events[channel_name].connect(
-					"interrupted", 
-					self, 
+					"interrupted",
+					self,
 					"_on_event_finished",
 					[channel_name],
 					CONNECT_ONESHOT
 				)
-			
+
 			if channel_name == CHANNEL_FRONT:
 				emit_signal(
 					"event_started",
@@ -106,21 +106,21 @@ func _process(delta: float) -> void:
 				)
 			else:
 				emit_signal(
-					"background_event_started", 
-					channel_name, 
+					"background_event_started",
+					channel_name,
 					_running_events[channel_name].name
 				)
-				
+
 			var event_flags = _running_events[channel_name].flags
 			if event_flags & ESCEvent.FLAG_NO_TT:
 				escoria.main.current_scene.game.tooltip_node.hide()
-			
+
 			if event_flags & ESCEvent.FLAG_NO_UI:
 				escoria.main.current_scene.game.hide_ui()
-			
+
 			if event_flags & ESCEvent.FLAG_NO_SAVE:
 				escoria.save_manager.save_enabled = false
-				
+
 			_running_events[channel_name].run()
 	for event in self.scheduled_events:
 		(event as ESCScheduledEvent).timeout -= delta
@@ -140,7 +140,7 @@ func _process(delta: float) -> void:
 #   (default: `false`)
 #
 # **Returns** indicator of success/status
-func queue_event_from_esc(script_object: ESCScript, event: String, 
+func queue_event_from_esc(script_object: ESCScript, event: String,
 	channel: String, block: bool) -> int:
 
 	if channel == CHANNEL_FRONT:
@@ -158,7 +158,7 @@ func queue_event_from_esc(script_object: ESCScript, event: String,
 			return rc
 		else:
 			var rc = yield(
-				escoria.event_manager, 
+				escoria.event_manager,
 				"background_event_finished"
 			)
 			while rc[1] != event and rc[2] != channel:
@@ -167,7 +167,7 @@ func queue_event_from_esc(script_object: ESCScript, event: String,
 					"background_event_finished"
 				)
 			return rc
-			
+
 	return ESCExecution.RC_OK
 
 
@@ -197,7 +197,7 @@ func schedule_event(event: ESCEvent, timeout: float) -> void:
 func queue_background_event(channel_name: String, event: ESCEvent) -> void:
 	if not channel_name in events_queue:
 		events_queue[channel_name] = []
-	
+
 	events_queue[channel_name].append(event)
 
 
@@ -213,7 +213,7 @@ func interrupt_running_event():
 func clear_event_queue():
 	for channel_name in events_queue.keys():
 		events_queue[channel_name].clear()
-		
+
 
 # Check wether a channel is free to run more events
 #
@@ -250,37 +250,37 @@ func _on_event_finished(finished_statement: ESCStatement, return_code: int, chan
 			]
 		)
 		return
-	
+
 	escoria.logger.debug(
 		"Event %s ended with return code %d" % [event.name, return_code]
 	)
-	
+
 	var event_flags = event.flags
 	if event_flags & ESCEvent.FLAG_NO_TT:
 		escoria.main.current_scene.game.tooltip_node.show()
-	
+
 	if event_flags & ESCEvent.FLAG_NO_UI:
 		escoria.main.current_scene.game.show_ui()
-	
+
 	if event_flags & ESCEvent.FLAG_NO_SAVE:
 		escoria.save_manager.save_enabled = true
-	
+
 	if return_code == ESCExecution.RC_CANCEL:
 		return_code = ESCExecution.RC_OK
 
 	_running_events[channel_name] = null
 	_channels_state[channel_name] = true
-	
+
 	if channel_name == CHANNEL_FRONT:
 		emit_signal(
-			"event_finished", 
+			"event_finished",
 			return_code,
 			event.name
 		)
 	else:
 		emit_signal(
-			"background_event_finished", 
+			"background_event_finished",
 			return_code,
-			event.name, 
+			event.name,
 			channel_name
 		)

--- a/addons/escoria-core/game/core-scripts/esc/esc_globals_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_globals_manager.gd
@@ -44,10 +44,10 @@ func register_reserved_global(key: String, value = null) -> void:
 	var old_value = _globals[key] if _globals.has(key) else ""
 	_reserved_globals[key] = value
 	_globals[key] = value
-	
+
 	if value != null:
 		emit_signal("global_changed", key, old_value, _globals[key])
-	
+
 
 # Get the current value of a global
 #
@@ -59,8 +59,8 @@ func get_global(key: String):
 	if _globals.has(key):
 		return _globals[key]
 	return null
-	
-	
+
+
 # Filter the globals and return all matching keys and their values as
 # a dictionary
 # Check out [the Godot docs](https://docs.godotengine.org/en/stable/classes/class_string.html#class-string-method-match)
@@ -93,19 +93,19 @@ func set_global(key: String, value, ignore_reserved: bool = false) -> void:
 			]
 		)
 	emit_signal(
-		"global_changed", 
-		key, 
-		_globals[key] if _globals.has(key) else null, 
+		"global_changed",
+		key,
+		_globals[key] if _globals.has(key) else null,
 		value
 	)
 	_globals[key] = value
-	
-	
-	
+
+
+
 # Set all globals that match the pattern to the value
 # Check out [the Godot docs](https://docs.godotengine.org/en/stable/classes/class_string.html#class-string-method-match)
 # for the pattern format
-# 
+#
 # #### Parameters
 #
 # - pattern: The wildcard pattern to match

--- a/addons/escoria-core/game/core-scripts/esc/esc_object_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_object_manager.gd
@@ -41,45 +41,45 @@ func register_object(object: ESCObject, force: bool = false) -> void:
 			"esc_object_manager.gd:register_object()",
 			[
 				"Registering object with empty global_id.",
-				"Using node's full path as global_id: %s" 
+				"Using node's full path as global_id: %s"
 						% object.node.global_id
 			]
 		)
-		
-	
+
+
 	if objects.has(object.global_id) and not force:
 		escoria.logger.report_errors(
 			"ESCObjectManager.register_object: Object already registered",
 			[
-				"Object with global id %s already registered" % 
+				"Object with global id %s already registered" %
 						object.global_id
 			]
 		)
 	else:
 		if not object.node.is_connected(
-			"tree_exited", 
-			self, 
+			"tree_exited",
+			self,
 			"unregister_object"
 		):
 			object.node.connect(
-				"tree_exited", 
-				self, 
-				"unregister_object", 
+				"tree_exited",
+				self,
+				"unregister_object",
 				[object]
 			)
-		
+
 		if "is_interactive" in object.node and object.node.is_interactive:
 			object.interactive = true
-		
+
 		if "esc_script" in object.node and not object.node.esc_script.empty():
 			var script = escoria.esc_compiler.load_esc_file(
 				object.node.esc_script
 			)
 			object.events = script.events
-		
+
 		objects[object.global_id] = object
-		
-		
+
+
 # Check wether an object was registered
 #
 # #### Parameters
@@ -95,7 +95,7 @@ func has(global_id: String) -> bool:
 # #### Parameters
 #
 # - global_id: The global id of the object to retrieve
-# **Returns** The retrieved object, or null if not found 
+# **Returns** The retrieved object, or null if not found
 func get_object(global_id: String) -> ESCObject:
 	if objects.has(global_id):
 		return objects[global_id]
@@ -108,8 +108,8 @@ func get_object(global_id: String) -> ESCObject:
 			]
 		)
 		return null
-		
-		
+
+
 # Remove an object from the registry
 #
 # #### Parameters

--- a/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
@@ -38,28 +38,28 @@ func _init() -> void:
 func register_reserved_globals() -> void:
 	for key in RESERVED_GLOBALS:
 		escoria.globals_manager.register_reserved_global( \
-			key, 
+			key,
 			RESERVED_GLOBALS[key])
 
 
-# Performs the actions needed in order to change the current scene to the one 
+# Performs the actions needed in order to change the current scene to the one
 # specified by room_path.
 #
 # #### Parameters
 #
 # - room_path: Node path to the room that is to become the new current room.
-# - enable_automatic_transitions: Whether to play the transition between rooms 
+# - enable_automatic_transitions: Whether to play the transition between rooms
 #	automatically or to leave the responsibility to the developer.
 func change_scene(room_path: String, enable_automatic_transitions: bool) -> void:
 	# Clear the event queue to remove other events (there could be duplicate
 	# events in there so we avoid running these multiple times)
 	escoria.event_manager.clear_event_queue()
-	
+
 	var exited_previous_room = false
-	
-	# If auto transition is enabled, try to determine whether we just exited a 
+
+	# If auto transition is enabled, try to determine whether we just exited a
 	# room previously, so that we must play the auto transition out or not.
-	# This must happen if ESC_LAST_SCENE is set, or if we're running an 
+	# This must happen if ESC_LAST_SCENE is set, or if we're running an
 	# exit_scene event. Also room selector actions require the transition.
 	if enable_automatic_transitions and (
 		not escoria.globals_manager.get_global( \
@@ -68,8 +68,8 @@ func change_scene(room_path: String, enable_automatic_transitions: bool) -> void
 			escoria.event_manager.get_running_event(escoria.event_manager.CHANNEL_FRONT) != null \
 			and escoria.event_manager.get_running_event(escoria.event_manager.CHANNEL_FRONT).name \
 				in [
-					escoria.event_manager.EVENT_NEW_GAME, 
-					escoria.event_manager.EVENT_EXIT_SCENE, 
+					escoria.event_manager.EVENT_NEW_GAME,
+					escoria.event_manager.EVENT_EXIT_SCENE,
 					escoria.event_manager.EVENT_ROOM_SELECTOR
 				]
 				and escoria.globals_manager.get_global(
@@ -77,20 +77,20 @@ func change_scene(room_path: String, enable_automatic_transitions: bool) -> void
 				).empty()
 			)
 		):
-		
+
 		exited_previous_room = true
-		
+
 		var transition_id = escoria.main.scene_transition.transition(
-			"", 
+			"",
 			ESCTransitionPlayer.TRANSITION_MODE.OUT
 		)
-		
+
 		escoria.logger.debug(
 			"Awaiting transition %s (out) to be finished." % str(transition_id)
 		)
-		
+
 		yield(escoria.main.scene_transition, "transition_done")
-	
+
 		# Hide main and pause menus
 		escoria.game_scene.hide_main_menu()
 		escoria.game_scene.unpause_game()
@@ -100,23 +100,23 @@ func change_scene(room_path: String, enable_automatic_transitions: bool) -> void
 		GLOBAL_FORCE_LAST_SCENE_NULL):
 
 		escoria.globals_manager.set_global(
-			GLOBAL_LAST_SCENE, 
-			null, 
+			GLOBAL_LAST_SCENE,
+			null,
 			true
 		)
 	elif escoria.main.current_scene:
 		# If FORCE_LAST_SCENE_NULL is false, set ESC_LAST_SCENE = current roomid
 		escoria.globals_manager.set_global(
-			GLOBAL_LAST_SCENE, 
-			escoria.main.current_scene.global_id, 
+			GLOBAL_LAST_SCENE,
+			escoria.main.current_scene.global_id,
 			true
 		)
-	
+
 	if escoria.dialog_player:
 		escoria.dialog_player.interrupt()
-	
+
 	escoria.inputs_manager.clear_stack()
-	
+
 	# Check if game scene was loaded
 	if not escoria.game_scene:
 		escoria.logger.report_errors(
@@ -135,7 +135,7 @@ func change_scene(room_path: String, enable_automatic_transitions: bool) -> void
 
 	# Load room scene
 	var res_room = escoria.resource_cache.get_resource(room_path)
-			
+
 	var room_scene = res_room.instance()
 	if room_scene:
 		if enable_automatic_transitions \
@@ -147,34 +147,34 @@ func change_scene(room_path: String, enable_automatic_transitions: bool) -> void
 			room_scene.enabled_automatic_transitions = enable_automatic_transitions
 
 		room_scene.exited_previous_room = exited_previous_room
-		
+
 		# If the game scene is already in the tree but not a child of the room
 		# we remove it
 		if escoria.game_scene.is_inside_tree() \
 				and escoria.game_scene.get_parent() != room_scene:
 			var game_parent = escoria.game_scene.get_parent()
 			game_parent.remove_child(escoria.game_scene)
-		
+
 		room_scene.add_child(escoria.game_scene)
 		room_scene.move_child(escoria.game_scene, 0)
 		room_scene.game = escoria.game_scene
 		escoria.main.set_scene(room_scene)
-		
+
 		# We know the scene has been loaded. Make its global ID available for
 		# use by ESC script.
 		escoria.globals_manager.set_global(
-			escoria.room_manager.GLOBAL_CURRENT_SCENE, 
-			room_scene.global_id, 
+			escoria.room_manager.GLOBAL_CURRENT_SCENE,
+			room_scene.global_id,
 			true
 		)
 
 		# Clear queued resources
 		escoria.resource_cache.clear()
-		
+
 		escoria.inputs_manager.hotspot_focused = ""
 	else:
 		escoria.logger.report_errors(
-			"ESCRoomManager.change_scene: Failed loading room scene", 
+			"ESCRoomManager.change_scene: Failed loading room scene",
 			[
 				"Failed loading scene %s" % room_path
 			]
@@ -195,7 +195,7 @@ func init_room(room: ESCRoom) -> void:
 				"No valid room was specified for initialization."
 			]
 		)
-		
+
 	if room.camera_limits.empty():
 		room.camera_limits.push_back(Rect2())
 
@@ -204,10 +204,10 @@ func init_room(room: ESCRoom) -> void:
 			if child is ESCBackground:
 				room.camera_limits[0] = \
 					Rect2(0, 0, child.rect_size.x, child.rect_size.y)
-		
+
 	if Engine.is_editor_hint():
 		return
-	
+
 	if room.has_node("game"):
 		room.game = room.get_node("game")
 
@@ -215,7 +215,7 @@ func init_room(room: ESCRoom) -> void:
 		room.game = escoria.game_scene
 		room.add_child(room.game)
 		room.move_child(room.game, 0)
-	
+
 	# Determine whether this room was run from change_scene or directly
 	if escoria.main.has_node(room.name):
 		room.is_run_directly = false
@@ -223,7 +223,7 @@ func init_room(room: ESCRoom) -> void:
 		room.is_run_directly = true
 		if escoria.main.current_scene == null:
 			escoria.main.set_scene(room)
-	
+
 	if room.player_scene:
 		room.player = room.player_scene.instance()
 		room.add_child(room.player)
@@ -240,7 +240,7 @@ func init_room(room: ESCRoom) -> void:
 			var animations = escoria.globals_manager.get_global(
 				escoria.room_manager.GLOBAL_ANIMATION_RESOURCES
 			)
-			
+
 			if room.player.global_id in animations and \
 					ResourceLoader.exists(animations[room.player.global_id]):
 				room.player.animations = ResourceLoader.load(
@@ -248,15 +248,15 @@ func init_room(room: ESCRoom) -> void:
 				)
 				room.player.update_idle()
 		escoria.object_manager.get_object(escoria.object_manager.CAMERA).node.set_target(room.player)
-	
+
 	if room.global_id.empty():
 		room.global_id = room.name
-	
+
 	# Manage player location at room start
 	if room.player != null \
 			and escoria.object_manager.get_start_location() != null:
 		room.player.teleport(escoria.object_manager.get_start_location().node)
-	
+
 	_perform_script_events(room)
 
 
@@ -274,7 +274,7 @@ func _perform_script_events(room: ESCRoom):
 					escoria.event_manager.CHANNEL_FRONT
 				).name == escoria.event_manager.EVENT_LOAD
 			):
-			
+
 		# If the room was loaded from change_scene and automatic transitions
 		# are not disabled, do the transition out now
 		if room.enabled_automatic_transitions \
@@ -282,7 +282,7 @@ func _perform_script_events(room: ESCRoom):
 				and not room.exited_previous_room:
 			var script_transition_out = escoria.esc_compiler.compile([
 				"%s%s" % [ESCEvent.PREFIX, escoria.event_manager.EVENT_TRANSITION_OUT],
-				"%s %s out" % 
+				"%s %s out" %
 					[
 						_transition.get_command_name(),
 						escoria.project_settings_manager.get_setting(
@@ -294,24 +294,24 @@ func _perform_script_events(room: ESCRoom):
 			escoria.event_manager.queue_event(
 				script_transition_out.events[escoria.event_manager.EVENT_TRANSITION_OUT]
 			)
-			
+
 			# Unpause the game if it was
 			escoria.set_game_paused(false)
-			
+
 			# Wait for transition_out event to be done
 			var rc = yield(escoria.event_manager, "event_finished")
 			while rc[1] != escoria.event_manager.EVENT_TRANSITION_OUT:
 				rc = yield(escoria.event_manager, "event_finished")
 			if rc[0] != ESCExecution.RC_OK:
 				return rc[0]
-			
+
 			# Hide main and pause menus
 			escoria.game_scene.hide_main_menu()
 			escoria.game_scene.unpause_game()
-			
+
 		# Run the setup event
 		_run_script_event(escoria.event_manager.EVENT_SETUP, room)
-		
+
 		if room.enabled_automatic_transitions \
 				or (
 					not room.enabled_automatic_transitions \
@@ -320,23 +320,23 @@ func _perform_script_events(room: ESCRoom):
 				):
 			var script_transition_in = escoria.esc_compiler.compile([
 				"%s%s" % [ESCEvent.PREFIX, escoria.event_manager.EVENT_TRANSITION_IN],
-				"%s %s in" % 
+				"%s %s in" %
 					[
 						_transition.get_command_name(),
 						escoria.project_settings_manager.get_setting(
 							escoria.project_settings_manager.DEFAULT_TRANISITION
 						)
-					],				
+					],
 				"%s 0.1" % _wait.get_command_name()
 			])
 			escoria.event_manager.queue_event(
 				script_transition_in.events[escoria.event_manager.EVENT_TRANSITION_IN]
 			)
-		
+
 		var ready_event_added: bool = false
 		# Run the ready event, if there is one.
 		ready_event_added = _run_script_event(escoria.event_manager.EVENT_READY, room)
-		
+
 		if ready_event_added:
 			# Wait for ready event to be done
 			var rc = yield(escoria.event_manager, "event_finished")
@@ -344,29 +344,29 @@ func _perform_script_events(room: ESCRoom):
 				rc = yield(escoria.event_manager, "event_finished")
 			if rc[0] != ESCExecution.RC_OK:
 				return rc[0]
-		
-		# Now that :ready is finished, if FORCE_LAST_SCENE_NULL was true, reset it 
+
+		# Now that :ready is finished, if FORCE_LAST_SCENE_NULL was true, reset it
 		# to false
 		if escoria.globals_manager.get_global( \
 			escoria.room_manager.GLOBAL_FORCE_LAST_SCENE_NULL):
 
 			escoria.globals_manager.set_global(
-				escoria.room_manager.GLOBAL_FORCE_LAST_SCENE_NULL, 
-				false, 
+				escoria.room_manager.GLOBAL_FORCE_LAST_SCENE_NULL,
+				false,
 				true
 			)
 			escoria.globals_manager.set_global(
 				escoria.room_manager.GLOBAL_LAST_SCENE,
 				escoria.main.current_scene.global_id \
-						if escoria.main.current_scene != null else "", 
+						if escoria.main.current_scene != null else "",
 				true
 			)
-		
+
 		# Make the room's global ID available for use in ESC script.
 		escoria.globals_manager.set_global(
 			escoria.room_manager.GLOBAL_CURRENT_SCENE,
 			escoria.main.current_scene.global_id \
-					if escoria.main.current_scene != null else "", 
+					if escoria.main.current_scene != null else "",
 			true
 		)
 
@@ -386,13 +386,13 @@ func _run_script_event(event_name: String, room: ESCRoom):
 	if room.compiled_script == null:
 		room.compiled_script = \
 			escoria.esc_compiler.load_esc_file(room.esc_script)
-	
+
 	if room.compiled_script.events.has(event_name):
 		escoria.logger.debug(
-			"esc_room:_run_script_event", 
+			"esc_room:_run_script_event",
 			[
 				"Queuing room script event %s" % event_name,
-				"Composed of %s statements" % 
+				"Composed of %s statements" %
 					str(room.compiled_script.events[event_name].statements.size())
 			]
 		)

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_base_command.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_base_command.gd
@@ -4,7 +4,7 @@ extends Node
 class_name ESCBaseCommand
 
 
-# Regex for creating command name based on the script's filename, including 
+# Regex for creating command name based on the script's filename, including
 # named groups
 const PATH_REGEX_GROUP = "path"
 const FILE_REGEX_GROUP = "file"
@@ -24,7 +24,7 @@ func _init() -> void:
 func configure() -> ESCCommandArgumentDescriptor:
 	escoria.logger.error("Command %s did not override configure." % get_class())
 	return ESCCommandArgumentDescriptor.new()
-	
+
 
 # Validate wether the given arguments match the command descriptor
 func validate(arguments: Array) -> bool:

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
@@ -24,20 +24,20 @@ var conditions: Array = []
 func _init(command_string):
 	var command_regex = RegEx.new()
 	command_regex.compile(REGEX)
-	
+
 	if command_regex.search(command_string):
 		for result in command_regex.search_all(command_string):
 			if "name" in result.names:
 				self.name = escoria.utils.get_re_group(result, "name")
 			if "parameters" in result.names:
-				# Split parameters by whitespace but allow quoted 
+				# Split parameters by whitespace but allow quoted
 				# parameters
 				var quote_open = false
 				var parameter_values = PoolStringArray([])
 				var parsed_parameters = \
 					escoria.utils.sanitize_whitespace(
 						escoria.utils.get_re_group(
-							result, 
+							result,
 							"parameters"
 						).strip_edges()
 					)
@@ -65,7 +65,7 @@ func _init(command_string):
 						parameters.append(parameter)
 			if "conditions" in result.names:
 				for condition in escoria.utils.get_re_group(
-							result, 
+							result,
 							"conditions"
 						).split(","):
 					self.conditions.append(
@@ -90,7 +90,7 @@ func is_valid() -> bool:
 			]
 		)
 		return false
-			
+
 	return .is_valid()
 
 

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_command_argument_descriptor.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_command_argument_descriptor.gd
@@ -20,8 +20,8 @@ var strip_quotes: Array = []
 
 # Initialize the descriptor
 func _init(
-	p_min_args: int = 0, 
-	p_types: Array = [], 
+	p_min_args: int = 0,
+	p_types: Array = [],
 	p_defaults: Array = [],
 	p_strip_quotes: Array = [true]
 ):
@@ -34,7 +34,7 @@ func _init(
 # Combine the default argument values with the given arguments
 func prepare_arguments(arguments: Array) -> Array:
 	var complete_arguments = defaults
-	
+
 	for index in range(arguments.size()):
 		complete_arguments[index] = escoria.utils.get_typed_value(
 			arguments[index],
@@ -43,13 +43,13 @@ func prepare_arguments(arguments: Array) -> Array:
 		var strip = strip_quotes[0]
 		if strip_quotes.size() == complete_arguments.size():
 			strip = strip_quotes[index]
-		
+
 		if strip and typeof(complete_arguments[index]) == TYPE_STRING:
 			complete_arguments[index] = complete_arguments[index].replace(
 				'"',
 				''
 			)
-	
+
 	return complete_arguments
 
 
@@ -64,7 +64,7 @@ func validate(command: String, arguments: Array) -> bool:
 					arguments
 			]
 		)
-	
+
 	for index in range(arguments.size()):
 		if arguments[index] == null:
 			# No type checking for null values
@@ -78,10 +78,10 @@ func validate(command: String, arguments: Array) -> bool:
 		for type in self.types[types_index]:
 			if not correct:
 				correct = self._is_type(arguments[index], type)
-			
+
 		if not correct:
 			escoria.logger.report_errors(
-				"Argument type did not match descriptor for command %s" % 
+				"Argument type did not match descriptor for command %s" %
 						command,
 				[
 					"Argument %d is of type %d. Expected %s" % [
@@ -93,7 +93,7 @@ func validate(command: String, arguments: Array) -> bool:
 					]
 				]
 			)
-	
+
 	return true
 
 
@@ -106,4 +106,4 @@ func validate(command: String, arguments: Array) -> bool:
 # *Returns* Wether the argument is of the given type
 func _is_type(argument, type: int) -> bool:
 	return typeof(argument) == type
-		
+

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_condition.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_condition.gd
@@ -5,10 +5,10 @@ class_name ESCCondition
 
 # Valid comparison types
 enum {
-	COMPARISON_NONE, 
-	COMPARISON_EQ, 
-	COMPARISON_GT, 
-	COMPARISON_LT, 
+	COMPARISON_NONE,
+	COMPARISON_EQ,
+	COMPARISON_GT,
+	COMPARISON_LT,
 	COMPARISON_ACTIVITY
 }
 
@@ -50,7 +50,7 @@ func _init(comparison_string: String):
 	comparison_regex.compile(
 		REGEX
 	)
-	
+
 	if comparison_regex.search(comparison_string):
 		for result in comparison_regex.search_all(comparison_string):
 			if "is_negated" in result.names:
@@ -61,12 +61,12 @@ func _init(comparison_string: String):
 					"gt": self.comparison = COMPARISON_GT
 					"lt": self.comparison = COMPARISON_LT
 					_: escoria.logger.report_errors(
-						"Invalid comparison type detected: %s" % 
+						"Invalid comparison type detected: %s" %
 								comparison_string,
 						[
-							"Comparison type %s unknown" % 
+							"Comparison type %s unknown" %
 									escoria.utils.get_re_group(
-										result, 
+										result,
 										"comparison"
 									)
 						]
@@ -74,7 +74,7 @@ func _init(comparison_string: String):
 			if "comparison_value" in result.names:
 				self.comparison_value = 	escoria.utils.get_typed_value(
 					escoria.utils.get_re_group(
-						result, 
+						result,
 						"comparison_value"
 					)
 				)
@@ -91,7 +91,7 @@ func _init(comparison_string: String):
 				"Comparison regexp didn't match"
 			]
 		)
-		
+
 
 # Run this comparison against the globals
 func run() -> bool:
@@ -106,12 +106,12 @@ func run() -> bool:
 					else self.comparison_value
 		]
 	)
-	
+
 	if self.inventory:
 		global_name = "i/%s" % flag
-		
+
 	var return_value = false
-	
+
 	if self.comparison == COMPARISON_NONE and \
 			escoria.globals_manager.has(global_name) and \
 			escoria.globals_manager.get_global(global_name) is bool and \
@@ -133,12 +133,12 @@ func run() -> bool:
 			escoria.object_manager.has(global_name) and \
 				escoria.object_manager.get_object(global_name).active:
 		return_value = true
-		
+
 	if self.negated:
 		return_value = not return_value
-		
+
 	escoria.logger.debug(
 		"It is" if return_value else "It isn't"
 	)
-	
+
 	return return_value

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
@@ -34,7 +34,7 @@ var options: Array
 func load_string(dialog_string: String):
 	var dialog_regex = RegEx.new()
 	dialog_regex.compile(REGEX)
-	
+
 	if dialog_regex.search(dialog_string):
 		for result in dialog_regex.search_all(dialog_string):
 			if "avatar" in result.names:
@@ -71,7 +71,7 @@ func is_valid() -> bool:
 			[]
 		)
 		return false
-		
+
 	return true
 
 
@@ -85,7 +85,7 @@ func run():
 		)
 	escoria.dialog_player.start_dialog_choices(self)
 	var option = yield(
-		escoria.dialog_player, 
+		escoria.dialog_player,
 		"option_chosen"
 	) as ESCDialogOption
 	var rc = option.run()

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_dialog_option.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_dialog_option.gd
@@ -23,7 +23,7 @@ var conditions: Array = []
 func load_string(option_string: String):
 	var option_regex = RegEx.new()
 	option_regex.compile(REGEX)
-	
+
 	if option_regex.search(option_string):
 		for result in option_regex.search_all(option_string):
 			if "option" in result.names:
@@ -37,7 +37,7 @@ func load_string(option_string: String):
 				]
 			if "conditions" in result.names:
 				for condition_text in escoria.utils.get_re_group(
-							result, 
+							result,
 							"conditions"
 						).split(","):
 					self.conditions.append(

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_event.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_event.gd
@@ -21,20 +21,20 @@ const PREFIX = ":"
 
 
 # Valid event flags
-# * TK: stands for "telekinetic". It means the player won't walk over to 
+# * TK: stands for "telekinetic". It means the player won't walk over to
 #   the item to say the line.
-# * NO_TT: stands for "No tooltip". It hides the tooltip for the duration of 
+# * NO_TT: stands for "No tooltip". It hides the tooltip for the duration of
 #   the event. Probably not very useful, because events having multiple
 #   say commands in them are automatically hidden.
-# * NO_UI: stands for "No User Inteface". It hides the UI for the duration of 
-#   the event. Useful when you want something to look like a cut scene but not 
+# * NO_UI: stands for "No User Inteface". It hides the UI for the duration of
+#   the event. Useful when you want something to look like a cut scene but not
 #   disable input for skipping dialog.
-# * NO_SAVE: disables saving. Use this in cut scenes and anywhere a 
+# * NO_SAVE: disables saving. Use this in cut scenes and anywhere a
 #   badly-timed autosave would leave your game in a messed-up state.
 enum {
-	FLAG_TK = 1, 
-	FLAG_NO_TT = 2, 
-	FLAG_NO_UI = 4, 
+	FLAG_TK = 1,
+	FLAG_NO_TT = 2,
+	FLAG_NO_UI = 4,
 	FLAG_NO_SAVE = 8
 }
 
@@ -50,7 +50,7 @@ var flags: int = 0
 func _init(event_string: String):
 	var event_regex = RegEx.new()
 	event_regex.compile(REGEX)
-	
+
 	if event_regex.search(event_string):
 		for result in event_regex.search_all(event_string):
 			if "name" in result.names:
@@ -58,7 +58,7 @@ func _init(event_string: String):
 					.strip_edges()
 			if "flags" in result.names:
 				var _flags = escoria.utils.get_re_group(
-						result, 
+						result,
 						"flags"
 					).strip_edges().split(" ")
 				if "TK" in _flags:

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_group.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_group.gd
@@ -16,12 +16,12 @@ var conditions: Array = []
 func _init(group_string: String):
 	var group_regex = RegEx.new()
 	group_regex.compile(REGEX)
-	
+
 	if group_regex.search(group_string):
 		for result in group_regex.search_all(group_string):
 			if "conditions" in result.names:
 				for condition in escoria.utils.get_re_group(
-						result, 
+						result,
 						"conditions"
 					).split(","):
 					self.conditions.append(

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_object.gd
@@ -12,7 +12,7 @@ var active: bool = true setget _set_active
 # Wether the object is interactive (clickable by the player)
 var interactive: bool = true setget _set_interactive, _get_interactive
 
-# The state of the object. If the object has a respective animation, 
+# The state of the object. If the object has a respective animation,
 # it will be played
 var state: String = "default"
 
@@ -36,10 +36,10 @@ func _init(p_global_id: String, p_node: Node):
 # - immediate: If true, skip directly to the end
 func set_state(p_state: String, immediate: bool = false):
 	state = p_state
-	
+
 	if node.has_method("get_animation_player"):
 		var animation_node: ESCAnimationPlayer = node.get_animation_player()
-	
+
 		if animation_node != null and animation_node.is_valid():
 			animation_node.stop()
 			var actual_animator
@@ -98,9 +98,9 @@ func _set_interactive(value: bool):
 # Return the data of the object to be inserted in a savegame file.
 #
 # **Returns**
-# A dictionary containing the data to be saved for this object. 
+# A dictionary containing the data to be saved for this object.
 func get_save_data() -> Dictionary:
-	var save_data: Dictionary = {} 
+	var save_data: Dictionary = {}
 	save_data["active"] = self.active
 	save_data["interactive"] = self.interactive
 	save_data["state"] = self.state
@@ -110,9 +110,9 @@ func get_save_data() -> Dictionary:
 		save_data["global_transform"] = self.node.global_transform
 		save_data["last_deg"] = wrapi(self.node._movable._get_angle() + 1, 0, 360)
 		save_data["last_dir"] = self.node._movable.last_dir
-	
+
 	if (self.global_id == "_music" or self.global_id == "_sound") \
 			and self.node.get("state"):
 		save_data["state"] = self.node.get("state")
-	
+
 	return save_data

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_statement.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_statement.gd
@@ -25,8 +25,8 @@ func is_valid() -> bool:
 		if not (condition as ESCCondition).run():
 			return false
 	return true
-	
-	
+
+
 # Execute this statement and return its return code
 func run() -> int:
 	var final_rc = ESCExecution.RC_OK
@@ -35,14 +35,14 @@ func run() -> int:
 			final_rc = ESCExecution.RC_CANCEL
 			emit_signal("interrupted", final_rc)
 			return final_rc
-		
+
 		if statement.is_valid():
 			var rc = statement.run()
 			if rc is GDScriptFunctionState:
 				rc = yield(rc, "completed")
 				escoria.logger.debug(
 					"esc_statement",
-					["Statement (%s) was completed." 
+					["Statement (%s) was completed."
 						% statement]
 				)
 				statement.is_finished = true
@@ -53,7 +53,7 @@ func run() -> int:
 			elif rc != ESCExecution.RC_OK:
 				final_rc = rc
 				break
-	
+
 	emit_signal("finished", self, final_rc)
 	return final_rc
 
@@ -72,7 +72,7 @@ func interrupt():
 			var name = statement.name if "name" in statement else "group"
 			escoria.logger.debug(
 				"event manager",
-				["Event %s (%s) is already finished. Won't interrupt." 
+				["Event %s (%s) is already finished. Won't interrupt."
 					% [name, str(statement)]]
 			)
 		else:

--- a/addons/escoria-core/game/core-scripts/esc_animation_player.gd
+++ b/addons/escoria-core/game/core-scripts/esc_animation_player.gd
@@ -102,7 +102,7 @@ func play(name: String, backwards: bool = false):
 		_animated_sprite.play(name, true)
 	else:
 		_player_node.play(name)
-	
+
 
 # Play the given animation backwards
 #
@@ -156,7 +156,7 @@ func get_length(name: String) -> float:
 
 # Return true if the ESCAnimationPlayer node is valid, ie. it has a valid player
 # node.
-# **Returns: true if the ESCAnimationPlayer has a valid player node, 
+# **Returns: true if the ESCAnimationPlayer has a valid player node,
 # else false**
 func is_valid() -> bool:
 	return _player_node != null and _player_node is Node

--- a/addons/escoria-core/game/core-scripts/esc_background.gd
+++ b/addons/escoria-core/game/core-scripts/esc_background.gd
@@ -1,12 +1,12 @@
-# ESCBackground's purpose is to display a background image and receive input 
-# events on the background. More precisely, the TextureRect under ESCBackground 
-# does not receive events itself - if it did, it would also eat all events like 
-# hotspot focusing and such. Instead, we set the TextureRect mouse filter to 
+# ESCBackground's purpose is to display a background image and receive input
+# events on the background. More precisely, the TextureRect under ESCBackground
+# does not receive events itself - if it did, it would also eat all events like
+# hotspot focusing and such. Instead, we set the TextureRect mouse filter to
 # MOUSE_FILTER_IGNORE, and we use an Area2D node to receive the input events.
-# 
-# If ESCBackground doesn't contain a texture, it is important that its rect_size 
-# is set over the whole scene, because its rect_size is then used to create the 
-# Area2D node under it. If the rect_size is wrongly set, the background may 
+#
+# If ESCBackground doesn't contain a texture, it is important that its rect_size
+# is set over the whole scene, because its rect_size is then used to create the
+# Area2D node under it. If the rect_size is wrongly set, the background may
 # receive no input.
 tool
 extends TextureRect
@@ -66,14 +66,14 @@ func _enter_tree():
 	# Set extents of RectangleShape2D to cover entire TextureRect
 	shape.set_extents(size / 2)
 	area.shape_owner_add_shape(sid, shape)
-	
+
 	add_child(area)
 
 # Disable mouse filter events and connect our own events to the ESC input
 # manager
 func _ready():
 	mouse_filter = MOUSE_FILTER_IGNORE
-	
+
 	if !Engine.is_editor_hint():
 		escoria.inputs_manager.register_background(self)
 
@@ -118,7 +118,7 @@ func get_full_area_rect2() -> Rect2:
 		size = get_texture().get_size()
 	else:
 		size = rect_size
-		
+
 	if rect_scale.x != 1 or rect_scale.y != 1:
 		size.x *= rect_scale.x
 		size.y *= rect_scale.y

--- a/addons/escoria-core/game/core-scripts/esc_exit.gd
+++ b/addons/escoria-core/game/core-scripts/esc_exit.gd
@@ -22,7 +22,7 @@ func _enter_tree():
 func _ready():
 	_play_snd = PlaySndCommand.new()
 	_change_scene = ChangeSceneCommand.new()
-	
+
 	call_deferred("_register_event")
 
 
@@ -35,16 +35,16 @@ func _register_event():
 		var exit_scene_event_script = [
 			"%s%s" % [ESCEvent.PREFIX, escoria.event_manager.EVENT_EXIT_SCENE]
 		]
-		
+
 		if switch_sound != "":
 			exit_scene_event_script.append(
 				"%s %s" % [_play_snd.get_command_name(), switch_sound]
 			)
-		
+
 		exit_scene_event_script.append(
 			"%s %s" % [_change_scene.get_command_name(), target_scene]
 		)
-		
+
 		var exit_scene_event = escoria.esc_compiler.compile(
 			exit_scene_event_script
 		).events[escoria.event_manager.EVENT_EXIT_SCENE]

--- a/addons/escoria-core/game/core-scripts/esc_game.gd
+++ b/addons/escoria-core/game/core-scripts/esc_game.gd
@@ -13,7 +13,7 @@ signal crash_popup_confirmed
 # NONE - No debugging
 # MOUSE_TOOLTIP_LIMITS - Visualize the tooltip limits
 enum EDITOR_GAME_DEBUG_DISPLAY {
-	NONE, 
+	NONE,
 	MOUSE_TOOLTIP_LIMITS
 }
 
@@ -39,13 +39,13 @@ var tooltip_node: Object
 # Function called when ESCGame enters the scene tree.
 func _enter_tree():
 	escoria.event_manager.connect(
-		"event_finished", 
-		self, 
+		"event_finished",
+		self,
 		"_on_event_done"
 	)
 	escoria.action_manager.connect(
-		"action_finished", 
-		self, 
+		"action_finished",
+		self,
 		"_on_action_finished"
 	)
 
@@ -53,13 +53,13 @@ func _enter_tree():
 # Function called when ESCGame exits the scene tree.
 func _exit_tree():
 	escoria.action_manager.disconnect(
-		"event_finished", 
-		self, 
+		"event_finished",
+		self,
 		"_on_event_done"
 	)
 	escoria.action_manager.disconnect(
-		"action_finished", 
-		self, 
+		"action_finished",
+		self,
 		"_on_action_finished"
 	)
 
@@ -77,13 +77,13 @@ func _draw():
 		return
 	if editor_debug_mode == EDITOR_GAME_DEBUG_DISPLAY.NONE:
 		return
-	
+
 	if editor_debug_mode == EDITOR_GAME_DEBUG_DISPLAY.MOUSE_TOOLTIP_LIMITS:
 		var mouse_limits: Rect2 = get_viewport_rect().grow(
 			-mouse_tooltip_margin
 		)
 		print(mouse_limits)
-		
+
 		# Draw lines for tooltip limits
 		draw_rect(mouse_limits, ColorN("red"), false, 10.0)
 
@@ -94,18 +94,18 @@ func _draw():
 #
 # - destination: Destination to walk to
 # - params: Parameters for the action
-# - can_interrupt: if true, this command will interrupt any ongoing event 
+# - can_interrupt: if true, this command will interrupt any ongoing event
 func do_walk(destination, params: Array = [], can_interrupt: bool = false) -> void:
 	if can_interrupt:
 		escoria.event_manager.interrupt_running_event()
-		
+
 	escoria.action_manager.clear_current_action()
-	
+
 	var walk_fast = false
-	
+
 	if params.size() > 1:
 		walk_fast = true if params[1] else false
-		
+
 	# Check moving object.
 	if not escoria.object_manager.has(params[0]):
 		escoria.logger.report_errors(
@@ -116,10 +116,10 @@ func do_walk(destination, params: Array = [], can_interrupt: bool = false) -> vo
 			]
 		)
 		return
-	
+
 	var moving_obj = escoria.object_manager.get_object(params[0])
 	var target
-	
+
 	if destination is String:
 		if not escoria.object_manager.has(destination):
 			escoria.logger.report_errors(
@@ -130,17 +130,17 @@ func do_walk(destination, params: Array = [], can_interrupt: bool = false) -> vo
 				]
 			)
 			return
-			
+
 		target = escoria.object_manager.get_object(destination)
 	elif destination is Vector2:
 		target = destination
-	
-	escoria.action_manager.perform_walk(moving_obj, target, walk_fast)	
+
+	escoria.action_manager.perform_walk(moving_obj, target, walk_fast)
 
 
 # Called when the player left clicks on the background
 # (Needs to be overridden, if supported)
-# 
+#
 # #### Parameters
 #
 # - position: Position clicked
@@ -154,10 +154,10 @@ func left_click_on_bg(position: Vector2) -> void:
 
 # Called when the player right clicks on the background
 # (Needs to be overridden, if supported)
-# 
+#
 # #### Parameters
 #
-# - position: Position clicked	
+# - position: Position clicked
 func right_click_on_bg(position: Vector2) -> void:
 	do_walk(
 		position,
@@ -168,7 +168,7 @@ func right_click_on_bg(position: Vector2) -> void:
 
 # Called when the player double clicks on the background
 # (Needs to be overridden, if supported)
-# 
+#
 # #### Parameters
 #
 # - position: Position clicked
@@ -233,14 +233,14 @@ func right_click_on_item(item_global_id: String, event: InputEvent) -> void:
 # - item_global_id: Global id of the item that was clicked
 # - event: The received input event
 func left_double_click_on_item(
-	item_global_id: String, 
+	item_global_id: String,
 	event: InputEvent
 ) -> void:
 	escoria.action_manager.do(
-		escoria.action_manager.ACTION.ITEM_LEFT_CLICK, 
+		escoria.action_manager.ACTION.ITEM_LEFT_CLICK,
 		[item_global_id, event],
 		true
-	) 
+	)
 
 
 # Called when an inventory item was left clicked
@@ -251,7 +251,7 @@ func left_double_click_on_item(
 # - inventory_item_global_id: Global id of the inventory item was clicked
 # - event: The received input event
 func left_click_on_inventory_item(
-	inventory_item_global_id: String, 
+	inventory_item_global_id: String,
 	event: InputEvent
 ) -> void:
 	pass
@@ -265,7 +265,7 @@ func left_click_on_inventory_item(
 # - inventory_item_global_id: Global id of the inventory item was clicked
 # - event: The received input event
 func right_click_on_inventory_item(
-	inventory_item_global_id: String, 
+	inventory_item_global_id: String,
 	event: InputEvent
 ) -> void:
 	pass
@@ -311,7 +311,7 @@ func open_inventory():
 # (Needs to be overridden, if supported)
 func close_inventory():
 	pass
-	
+
 
 # Called when the mousewheel was used
 # (Needs to be overridden, if supported)
@@ -327,7 +327,7 @@ func mousewheel_action(direction: int):
 # (Needs to be overridden, if supported)
 func hide_ui():
 	pass
-	
+
 
 # Called when the UI should be shown
 # (Needs to be overridden, if supported)
@@ -339,15 +339,15 @@ func show_ui():
 #
 # #### Parameter
 #
-# - p_editor_debug_mode: EDITOR_GAME_DEBUG_DISPLAY enum (int) value 
+# - p_editor_debug_mode: EDITOR_GAME_DEBUG_DISPLAY enum (int) value
 # corresponding to the desired editor debug mode
 func _set_editor_debug_mode(p_editor_debug_mode: int) -> void:
 	editor_debug_mode = p_editor_debug_mode
 	update()
 
 
-# Automatically called whenever an event is finished. Can be used to reset some 
-# UI elements to their default/empty state. This function can be called before 
+# Automatically called whenever an event is finished. Can be used to reset some
+# UI elements to their default/empty state. This function can be called before
 # _on_action_finished() if the player input started an event.
 # Reimplement to performed desired actions.
 #
@@ -359,8 +359,8 @@ func _on_event_done(_return_code: int, _event_name: String) -> void:
 	pass
 
 
-# Automatically called whenever an action initiated by the player is finished. 
-# Can be used to reset some UI elements to their default/empty state. 
+# Automatically called whenever an action initiated by the player is finished.
+# Can be used to reset some UI elements to their default/empty state.
 # Reimplement to performed desired actions.
 func _on_action_finished() -> void:
 	pass
@@ -386,16 +386,16 @@ func hide_main_menu():
 	pass
 
 
-# Custom function that is meant to apply custom settings. Called right after 
+# Custom function that is meant to apply custom settings. Called right after
 # Escoria settings file was loaded.
 func apply_custom_settings(custom_settings: Dictionary):
 	pass
 
 
-# Custom function automatically called when save game is created. 
+# Custom function automatically called when save game is created.
 #
 # *Returns* A Dictionary containing the custom data to be saved within the
-# game file. 
+# game file.
 func get_custom_data() -> Dictionary:
 	return {}
 

--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -57,7 +57,7 @@ export(String, FILE, "*.esc") var esc_script
 export(bool) var is_exit
 
 # If true, object is considered as trigger. Allows using :trigger_in and
-# :trigger_out verbs in ESC scripts. 
+# :trigger_out verbs in ESC scripts.
 export(bool) var is_trigger
 
 # The verb used for the trigger in ESC events
@@ -89,8 +89,8 @@ export(String) var default_action
 # Default action to use if object is in the inventory
 export(String) var default_action_inventory
 
-# If action used by player is in this list, the game will wait for a second 
-# click on another item to combine objects together (typical 
+# If action used by player is in this list, the game will wait for a second
+# click on another item to combine objects together (typical
 # `USE <X> WITH <Y>`, `GIVE <X> TO <Y>`)
 export(PoolStringArray) var combine_when_selected_action_is_in = []
 
@@ -156,33 +156,33 @@ var _animation_player: ESCAnimationPlayer = null
 # and register this item
 func _ready():
 	self.pause_mode = Node.PAUSE_MODE_STOP
-	
+
 	_detect_children()
-	
+
 	if not self.is_connected("mouse_entered", self, "_on_mouse_entered"):
 		connect("mouse_entered", self, "_on_mouse_entered")
 	if not self.is_connected("mouse_exited", self, "_on_mouse_exited"):
 		connect("mouse_exited", self, "_on_mouse_exited")
-	
+
 	# Register and connect all elements to Escoria backoffice.
 	if not Engine.is_editor_hint():
-		
+
 		if is_movable:
 			_movable = ESCMovable.new()
 
 			add_child(_movable)
-	
+
 		if not escoria.event_manager.is_connected(
 			"event_finished",
-			self, 
+			self,
 			"_update_terrain"
 		):
 			escoria.event_manager.connect(
-				"event_finished", 
-				self, 
+				"event_finished",
+				self,
 				"_update_terrain"
 			)
-		
+
 		escoria.object_manager.register_object(
 			ESCObject.new(
 				global_id,
@@ -190,58 +190,58 @@ func _ready():
 			),
 			true
 		)
-		
+
 		terrain = escoria.room_terrain
-		
+
 		if !is_trigger:
 			if not self.is_connected(
-				"mouse_entered_item", 
-				escoria.inputs_manager, 
+				"mouse_entered_item",
+				escoria.inputs_manager,
 				"_on_mouse_entered_item"
 			):
 				connect(
-					"mouse_entered_item", 
-					escoria.inputs_manager, 
+					"mouse_entered_item",
+					escoria.inputs_manager,
 					"_on_mouse_entered_item"
 				)
 			if not self.is_connected(
-				"mouse_exited_item", 
-				escoria.inputs_manager, 
+				"mouse_exited_item",
+				escoria.inputs_manager,
 				"_on_mouse_exited_item"
 			):
 				connect(
-					"mouse_exited_item", 
-					escoria.inputs_manager, 
+					"mouse_exited_item",
+					escoria.inputs_manager,
 					"_on_mouse_exited_item"
 				)
 			if not self.is_connected(
-				"mouse_left_clicked_item", 
-				escoria.inputs_manager, 
+				"mouse_left_clicked_item",
+				escoria.inputs_manager,
 				"_on_mouse_left_clicked_item"
 			):
 				connect(
-					"mouse_left_clicked_item", 
-					escoria.inputs_manager, 
+					"mouse_left_clicked_item",
+					escoria.inputs_manager,
 					"_on_mouse_left_clicked_item"
 				)
 			if not self.is_connected(
-				"mouse_double_left_clicked_item", 
-				escoria.inputs_manager, 
+				"mouse_double_left_clicked_item",
+				escoria.inputs_manager,
 				"_on_mouse_left_double_clicked_item"
 			):
 				connect(
-					"mouse_double_left_clicked_item", 
-					escoria.inputs_manager, 
+					"mouse_double_left_clicked_item",
+					escoria.inputs_manager,
 					"_on_mouse_left_double_clicked_item"
 				)
 			if not self.is_connected(
-				"mouse_right_clicked_item", 
-				escoria.inputs_manager, 
+				"mouse_right_clicked_item",
+				escoria.inputs_manager,
 				"_on_mouse_right_clicked_item"
 			):
 				connect(
-					"mouse_right_clicked_item", 
-					escoria.inputs_manager, 
+					"mouse_right_clicked_item",
+					escoria.inputs_manager,
 					"_on_mouse_right_clicked_item"
 				)
 		else:
@@ -253,12 +253,12 @@ func _ready():
 				connect("body_entered", self, "element_entered")
 			if not self.is_connected("body_exited", self, "element_exited"):
 				connect("body_exited", self, "element_exited")
-		
+
 	# If object can be in the inventory, set default_action_inventory to same as
 	# default_action, if default_action_inventory is not set
 	if use_from_inventory_only and default_action_inventory.empty():
 		default_action_inventory = default_action
-	
+
 	# Perform a first terrain scaling if we have to.
 	if (!is_exit or dont_apply_terrain_scaling) and is_movable:
 		_movable.last_scale = scale
@@ -278,8 +278,8 @@ func _unhandled_input(event: InputEvent) -> void:
 		var mouse_in_shape: bool = false
 		var colliders = get_world_2d().direct_space_state.intersect_point(
 			p,
-			32, 
-			[], 
+			32,
+			[],
 			2147483647,
 			true,
 			true
@@ -331,10 +331,10 @@ func get_interact_position() -> Vector2:
 	for c in get_children():
 		if c is Position2D:
 			interact_position = c.global_position
-			
+
 	if interact_position == null and collision != null:
 		interact_position = collision.global_position
-		
+
 	return interact_position
 
 
@@ -349,7 +349,7 @@ func _on_mouse_exited():
 
 
 # Another item (e.g. the player) has entered this item
-# 
+#
 # #### Parameters
 #
 # - body: Other object that has entered the item
@@ -357,7 +357,7 @@ func element_entered(body):
 	if body is ESCBackground or body.get_parent() is ESCBackground:
 		return
 	escoria.action_manager.do(
-		escoria.action_manager.ACTION.TRIGGER_IN, 
+		escoria.action_manager.ACTION.TRIGGER_IN,
 		[global_id, body.global_id, trigger_in_verb]
 	)
 
@@ -370,7 +370,7 @@ func element_exited(body):
 	if body is ESCBackground or body.get_parent() is ESCBackground:
 		return
 	escoria.action_manager.do(
-		escoria.action_manager.ACTION.TRIGGER_OUT, 
+		escoria.action_manager.ACTION.TRIGGER_OUT,
 		[global_id, body.global_id, trigger_out_verb]
 	)
 
@@ -391,7 +391,7 @@ func teleport(target: Node) -> void:
 # - target: Vector2 position to teleport to
 func teleport_to(target: Vector2) -> void:
 	_movable.teleport_to(target)
-	
+
 
 # Use the movable node to make the item walk to the given position
 #
@@ -410,7 +410,7 @@ func walk_to(pos: Vector2, p_walk_context: ESCWalkContext = null) -> void:
 # - speed_value: Set the new speed
 func set_speed(speed_value: int) -> void:
 	speed = speed_value
-	
+
 
 # Check wether this item moved
 func has_moved() -> bool:
@@ -527,18 +527,18 @@ func _get_property_list():
 func _set_animation_player_node(node_path: NodePath):
 	if not Engine.is_editor_hint():
 		return
-	
+
 	if node_path == "":
 		animation_player_node = node_path
 		return
-		
+
 	assert(has_node(node_path), "Node with path %s not found" % node_path)
 	assert(
 		get_node(node_path) is AnimatedSprite or \
 				get_node(node_path) is AnimationPlayer,
 		"Selected node has to be an AnimatedSprite or AnimationPlayer node"
 	)
-	
+
 	animation_player_node = node_path
 
 

--- a/addons/escoria-core/game/core-scripts/esc_location.gd
+++ b/addons/escoria-core/game/core-scripts/esc_location.gd
@@ -14,7 +14,7 @@ export(bool) var is_start_location = false
 # player character arrives.
 export(bool) var player_orients_on_arrival = true
 
-# Let the player turn to this direction when the player arrives 
+# Let the player turn to this direction when the player arrives
 # at the item
 export(int) var interaction_direction
 

--- a/addons/escoria-core/game/core-scripts/esc_resource_cache.gd
+++ b/addons/escoria-core/game/core-scripts/esc_resource_cache.gd
@@ -191,7 +191,7 @@ func start():
 	thread = Thread.new()
 	thread.start(self, "thread_func", 0)
 
-	
+
 	## Uncomment these for debug, or wait for someone to implement log levels
 	# connect("resource_loading_progress", self, "print_progress")
 	# connect("resource_loading_done", self, "res_loaded")

--- a/addons/escoria-core/game/core-scripts/esc_room.gd
+++ b/addons/escoria-core/game/core-scripts/esc_room.gd
@@ -8,7 +8,7 @@ class_name ESCRoom, "res://addons/escoria-core/design/esc_room.svg"
 # NONE: No debug display
 # CAMERA_LIMITS: Display the camera limits
 enum EditorRoomDebugDisplay {
-	NONE, 
+	NONE,
 	CAMERA_LIMITS
 }
 
@@ -68,22 +68,22 @@ func _draw():
 		return
 	if editor_debug_mode == EditorRoomDebugDisplay.NONE:
 		return
-		
+
 	var camera_limits_colors: Array = [
 		ColorN("red"), ColorN("blue"), ColorN("green")
 	]
-	
+
 	# If there are more camera limits than colors defined for them, add more.
 	if camera_limits.size() > camera_limits_colors.size():
 		for i in camera_limits.size() - camera_limits_colors.size():
 			camera_limits_colors.push_back(Color(randf(), randf(), randf(), 1.0))
-	
+
 	# Draw lines for camera limits
 	for i in camera_limits.size():
 		draw_rect(camera_limits[i], camera_limits_colors[i], false, 10.0)
 		var default_font = Control.new().get_font("font")
-		
-		draw_string(default_font, Vector2(camera_limits[i].position.x + 30, 
+
+		draw_string(default_font, Vector2(camera_limits[i].position.x + 30,
 			camera_limits[i].position.y + 30), str(i), camera_limits_colors[i])
 
 

--- a/addons/escoria-core/game/core-scripts/esc_terrain.gd
+++ b/addons/escoria-core/game/core-scripts/esc_terrain.gd
@@ -28,7 +28,7 @@ export(Texture) var lightmap setget _set_lightmap
 export(Vector2) var bitmaps_scale = Vector2(1,1) setget _set_bm_scale
 
 # Multiplier applied to the player speed on this terrain
-export(float) var player_speed_multiplier = 1.0  
+export(float) var player_speed_multiplier = 1.0
 
 # Multiplier how much faster the player will walk when fast mode is on
 # (double clicked)
@@ -65,7 +65,7 @@ func _ready():
 			if n.enabled:
 				if navigation_enabled_found:
 					escoria.logger.report_errors(
-						"ESCTerrain:_ready()", 
+						"ESCTerrain:_ready()",
 						[
 							"Multiple NavigationPolygonInstances enabled " + \
 							"at the same time."
@@ -73,8 +73,8 @@ func _ready():
 					)
 				navigation_enabled_found = true
 				current_active_navigation_instance = n
-	
-	
+
+
 	if !Engine.is_editor_hint():
 		escoria.room_terrain = self
 	_update_texture()
@@ -212,7 +212,7 @@ func _draw():
 		if current_active_navigation_instance:
 			current_active_navigation_instance.visible = true
 		return
-	
+
 	var scale_vect = bitmaps_scale
 
 	if current_active_navigation_instance:
@@ -220,9 +220,9 @@ func _draw():
 
 	var src = Rect2(0, 0, _texture.get_width(), _texture.get_height())
 	var dst = Rect2(
-		0, 
-		0, 
-		_texture.get_width() * scale_vect.x, 
+		0,
+		0,
+		_texture.get_width() * scale_vect.x,
 		_texture.get_height() * scale_vect.y
 	)
 

--- a/addons/escoria-core/game/core-scripts/esc_tooltip.gd
+++ b/addons/escoria-core/game/core-scripts/esc_tooltip.gd
@@ -1,4 +1,4 @@
-# A tooltip displaying <verb> <item1> [<item2>] 
+# A tooltip displaying <verb> <item1> [<item2>]
 tool
 extends RichTextLabel
 class_name ESCTooltip
@@ -50,8 +50,8 @@ var debug_texturerect_node: TextureRect
 func _ready():
 	escoria.main.connect("room_ready", self, "_on_room_ready")
 	escoria.action_manager.connect("action_changed", self, "_on_action_selected")
-	
-	
+
+
 # Set the color of the label
 #
 # ## Parameters
@@ -61,9 +61,9 @@ func set_color(p_color: Color):
 	update_tooltip_text()
 
 
-# Enable/disable debug mode of the label. If enabled, the label is displayed 
+# Enable/disable debug mode of the label. If enabled, the label is displayed
 # with a white background.
-# 
+#
 # ## Parameters
 # - p_debug_mode: if true, enable debug mode. False to disable
 func set_debug_mode(p_debug_mode: bool):
@@ -85,7 +85,7 @@ func set_debug_mode(p_debug_mode: bool):
 	else:
 		if debug_texturerect_node:
 			remove_child(debug_texturerect_node)
-	
+
 
 # Set the first target of the label.
 #
@@ -126,7 +126,7 @@ func update_size():
 	var content_height = get_content_height()
 	var nb_visible_characters = visible_characters
 	var nb_visible_lines = get_visible_line_count()
-	
+
 	# if text is too long and is wrapped
 	var nblines = nb_visible_lines
 	if nblines >= 1:
@@ -135,19 +135,19 @@ func update_size():
 			text_height = MAX_HEIGHT
 		if text_height <= MIN_HEIGHT:
 			text_height = MIN_HEIGHT
-		
+
 		var parent_width = rect_size.x
-		
+
 		# first, try to increase width until it goes above max_width
 		while parent_width < MAX_WIDTH && float(text_height) / float(ONE_LINE_HEIGHT) > 1.0:
 			rect_size.x += 1
 			parent_width = rect_size.x
-		
+
 		rect_size.y = text_height
-		
+
 		if rect_size.x >= MAX_WIDTH:
 			rect_size.x = MAX_WIDTH
-		
+
 	## END RECT_SIZE ##
 	anchor_top = 0.0
 	anchor_right = 0.0
@@ -156,7 +156,7 @@ func update_size():
 
 
 # Calculate the offset of the label depending on its position.
-# 
+#
 # ## Parameters
 # - position: the position to test
 #
@@ -165,10 +165,10 @@ func update_size():
 func _offset(position: Vector2) -> Vector2:
 	var center_offset_x = rect_size.x / 2
 	var offset_y = 5
-	
+
 	position.x -= center_offset_x
 	position.y += offset_y
-	
+
 	return position
 
 

--- a/addons/escoria-core/game/core-scripts/esc_walk_context.gd
+++ b/addons/escoria-core/game/core-scripts/esc_walk_context.gd
@@ -18,8 +18,8 @@ var dont_interact_on_arrival: bool
 
 
 func _init(
-	p_target_object: ESCObject, 
-	p_target_position: Vector2,  
+	p_target_object: ESCObject,
+	p_target_position: Vector2,
 	p_fast: bool,
 	p_dont_interact_on_arrival: bool
 ):

--- a/addons/escoria-core/game/core-scripts/log/esc_logger.gd
+++ b/addons/escoria-core/game/core-scripts/log/esc_logger.gd
@@ -38,7 +38,7 @@ var _level_map: Dictionary = {
 func _init():
 	# Open logfile in write mode
 	log_file = File.new()
-	
+
 	# this is left alone as this constructor is called from escoria.gd's own
 	# constructor
 	var log_file_path = ProjectSettings.get_setting(
@@ -50,7 +50,7 @@ func _init():
 			str(date["hour"]) + str(date["minute"]) + str(date["second"])
 		])
 	log_file.open(
-		log_file_path, 
+		log_file_path,
 		File.WRITE
 	)
 
@@ -58,7 +58,7 @@ func _init():
 # Log a trace message
 #
 # #### Parameters
-# 
+#
 # * string: Text to log
 # * args: Additional information
 func trace(string: String, args = []):
@@ -70,7 +70,7 @@ func trace(string: String, args = []):
 # Log a debug message
 #
 # #### Parameters
-# 
+#
 # * string: Text to log
 # * args: Additional information
 func debug(string: String, args = []):
@@ -82,7 +82,7 @@ func debug(string: String, args = []):
 # Log an info message
 #
 # #### Parameters
-# 
+#
 # * string: Text to log
 # * args: Additional information
 func info(string: String, args = []):
@@ -101,44 +101,44 @@ func info(string: String, args = []):
 # Log a warning message
 #
 # #### Parameters
-# 
+#
 # * string: Text to log
 # * args: Additional information
 func warning(string: String, args = []):
 	if _get_log_level() >= LOG_WARNING and !crashed:
 		var argsstr = str(args) if !args.empty() else ""
 		_log("(W)\t" + string + " \t" + argsstr, true)
-				
+
 		if escoria.project_settings_manager.get_setting(
 			escoria.project_settings_manager.TERMINATE_ON_WARNINGS
 		):
 			_perform_stack_trace_log()
 			crashed = true
-			
+
 			var files = "- %s" % log_file.get_path_absolute()
 			var message = escoria.project_settings_manager.get_setting(
 				escoria.project_settings_manager.CRASH_MESSAGE
-			) % files 
-			
+			) % files
+
 			_log(message, true)
 			escoria.set_game_paused(true)
 			escoria.main.current_scene.game.show_crash_popup(
 				[log_file.get_path_absolute()]
 			)
 			assert(false)
-			
+
 
 # Log an error message
 #
 # #### Parameters
-# 
+#
 # * string: Text to log
 # * args: Additional information
 func error(string: String, args = [], do_savegame: bool = true):
 	if _get_log_level() >= LOG_ERROR and !crashed:
 		var argsstr = str(args) if !args.empty() else ""
 		_log("(E)\t" + string + " \t" + argsstr, true)
-		
+
 		if escoria.project_settings_manager.get_setting(
 			escoria.project_settings_manager.TERMINATE_ON_ERRORS
 		):
@@ -146,19 +146,19 @@ func error(string: String, args = [], do_savegame: bool = true):
 			crashed = true
 			if do_savegame:
 				_perform_save_game_log()
-			
+
 			var files_to_send: Array = [
 				log_file.get_path_absolute().get_base_dir().plus_file(
 					escoria.save_manager.crash_savegame_filename.get_file()
 				),
-				log_file.get_path_absolute() 
+				log_file.get_path_absolute()
 			]
-			
+
 			var files = "- %s\n- %s" % files_to_send
 			var message = escoria.project_settings_manager.get_setting(
 				escoria.project_settings_manager.CRASH_MESSAGE
-			) % files 
-			
+			) % files
+
 			_log(message, true)
 			escoria.set_game_paused(true)
 			escoria.main.current_scene.game.show_crash_popup(files_to_send)
@@ -168,7 +168,7 @@ func error(string: String, args = [], do_savegame: bool = true):
 # Log a warning message about an ESC file
 #
 # #### Parameters
-# 
+#
 # * p_path: Path to the file
 # * warnings: Array of warnings to put out
 # * report_once: Additional messages about the same file will be ignored
@@ -176,7 +176,7 @@ func report_warnings(p_path: String, warnings: Array, report_once = false) -> vo
 	var warning_is_reported = false
 	if p_path == warning_path:
 		warning_is_reported = true
-		
+
 	if !warning_is_reported:
 		var text = "Warnings in file "+p_path+"\n"
 		for w in warnings:
@@ -185,7 +185,7 @@ func report_warnings(p_path: String, warnings: Array, report_once = false) -> vo
 			else:
 				text += w+"\n"
 		warning(text)
-	
+
 		if report_once:
 			warning_is_reported = true
 
@@ -193,7 +193,7 @@ func report_warnings(p_path: String, warnings: Array, report_once = false) -> vo
 # Log an error message about an ESC file
 #
 # #### Parameters
-# 
+#
 # * p_path: Path to the file
 # * errors: Array of errors to put out
 func report_errors(p_path: String, errors: Array) -> void:
@@ -211,7 +211,7 @@ func report_errors(p_path: String, errors: Array) -> void:
 # - in stdout, or stderr if err is true.
 #
 # #### Parameters
-# 
+#
 # * message: Message to log
 # * err: if true, write in stderr
 func _log(message:String, err: bool = false):
@@ -259,7 +259,7 @@ func _perform_stack_trace_log():
 # Write a message in the output logfile
 #
 # #### Parameters
-# 
+#
 # * message: Message to write
 func _write_logfile(message: String) -> void:
 	if log_file.is_open():

--- a/addons/escoria-core/game/core-scripts/migrations/esc_migration.gd
+++ b/addons/escoria-core/game/core-scripts/migrations/esc_migration.gd
@@ -13,13 +13,13 @@ var _savegame: ESCSaveGame
 # - savegame: Savegame to modify
 func set_savegame(savegame: ESCSaveGame):
 	_savegame = savegame
-	
+
 
 # Get the savegame
 # **Returns** Savegame
 func get_savegame():
 	return _savegame
-	
+
 
 # Override this function in the version script with
 # the things that need to be applied to the savegame

--- a/addons/escoria-core/game/core-scripts/migrations/esc_migration_manager.gd
+++ b/addons/escoria-core/game/core-scripts/migrations/esc_migration_manager.gd
@@ -24,19 +24,19 @@ func _init() -> void:
 #
 # Each migration will return a modified version of the given savegame
 func migrate(
-	savegame: ESCSaveGame, 
-	from: String, 
-	to: String, 
+	savegame: ESCSaveGame,
+	from: String,
+	to: String,
 	versions_directory: String
 ) -> ESCSaveGame:
 	escoria.logger.info("Migrating from version %s to %s" % [
 		from,
 		to
 	])
-	
+
 	var from_info = version_regex.search(from)
 	var to_info = version_regex.search(to)
-	
+
 	var wrong_version: bool = false
 	if from_info.get_string("major") > to_info.get_string("major"):
 		wrong_version = true
@@ -47,7 +47,7 @@ func migrate(
 			from_info.get_string("minor") == to_info.get_string("minor") and\
 			from_info.get_string("patch") > to_info.get_string("patch"):
 		wrong_version = true
-		
+
 	if wrong_version:
 		escoria.logger.report_errors(
 			"esc_migration_manager:migrate",
@@ -58,12 +58,12 @@ func migrate(
 				]
 			]
 		)
-	
+
 	var versions = _find_versions(versions_directory, from, to)
 	versions.sort_custom(self, "_compare_version")
 	if versions[0].get_file().get_basename() == from:
 		versions.pop_front()
-	
+
 	for version in versions:
 		var migration_script = load(version).new()
 		if not migration_script is ESCMigration:
@@ -77,7 +77,7 @@ func migrate(
 		(migration_script as ESCMigration).set_savegame(savegame)
 		(migration_script as ESCMigration).migrate()
 		savegame = (migration_script as ESCMigration).get_savegame()
-		
+
 	return savegame
 
 
@@ -125,7 +125,7 @@ func _version_between(version: String, from: String, to: String) -> bool:
 	var version_info = version_regex.search(version)
 	var from_info = version_regex.search(from)
 	var to_info = version_regex.search(to)
-	
+
 	if from_info.get_string("major") < version_info.get_string("major") and \
 			version_info.get_string("major") < to_info.get_string("major"):
 		return true
@@ -144,12 +144,12 @@ func _version_between(version: String, from: String, to: String) -> bool:
 			to_info.get_string("minor") == version_info.get_string("minor") and\
 			to_info.get_string("patch") > version_info.get_string("patch"):
 		return true
-	
+
 	return false
 
 
 # Compare to version strings
-# 
+#
 # #### Parameters
 # - version_a: First version to compare
 # - version_b: Second version to compare
@@ -157,7 +157,7 @@ func _version_between(version: String, from: String, to: String) -> bool:
 func _compare_version(version_a: String, version_b: String) -> bool:
 	var a_info = version_regex.search(version_a.get_file().get_basename())
 	var b_info = version_regex.search(version_b.get_file().get_basename())
-	
+
 	if a_info.get_string("major") < b_info.get_string("major"):
 		return true
 	elif a_info.get_string("major") == b_info.get_string("major") and \
@@ -167,6 +167,6 @@ func _compare_version(version_a: String, version_b: String) -> bool:
 			a_info.get_string("minor") == b_info.get_string("minor") and \
 			a_info.get_string("patch") < b_info.get_string("patch"):
 		return true
-	
+
 	return false
-	
+

--- a/addons/escoria-core/game/core-scripts/resources/esc_animationresource.gd
+++ b/addons/escoria-core/game/core-scripts/resources/esc_animationresource.gd
@@ -1,4 +1,4 @@
-# Resource containing all defined animations and angles for 
+# Resource containing all defined animations and angles for
 # characters movement.
 tool
 extends Resource
@@ -13,18 +13,18 @@ class_name ESCAnimationResource
 export(Array, Resource) var dir_angles: Array = []
 
 # Array of animations for each direction, from UP to RIGHT_UP clockwise
-# [animation_name, scale]: scale parameter can be set to -1 to mirror 
+# [animation_name, scale]: scale parameter can be set to -1 to mirror
 # the animation
 export(Array, Resource) var directions: Array = []
 
 
 # Array containing the idle animations for each direction (in the
-# order defined by dir_angles): scale parameter can be set to -1 to mirror 
+# order defined by dir_angles): scale parameter can be set to -1 to mirror
 # the animation
 export(Array, Resource) var idles: Array = []
 
 # Array containing the speak animations for each direction (in the
-# order defined by dir_angles): scale parameter can be set to -1 to mirror 
+# order defined by dir_angles): scale parameter can be set to -1 to mirror
 # the animation
 export(Array, Resource) var speaks: Array = []
 

--- a/addons/escoria-core/game/core-scripts/resources/esc_directionangle.gd
+++ b/addons/escoria-core/game/core-scripts/resources/esc_directionangle.gd
@@ -5,7 +5,7 @@ class_name ESCDirectionAngle
 
 
 # Start angle of the directional angle.
-export(int) var angle_start: int 
+export(int) var angle_start: int
 
 # Size of the angle
 export(int) var angle_size: int

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -56,7 +56,7 @@ func _init():
 	_play_snd = PlaySndCommand.new()
 
 
-# Return a list of savegames metadata (id, date, name and game version) 
+# Return a list of savegames metadata (id, date, name and game version)
 func get_saves_list() -> Dictionary:
 	var regex = RegEx.new()
 	regex.compile("save_(?<slotnumber>[0-9]{3})\\.tres")
@@ -70,7 +70,7 @@ func get_saves_list() -> Dictionary:
 			var save_path = save_folder.plus_file(nextfile)
 			var file: File = File.new()
 			var save_game_res: Resource = load(save_path)
-			
+
 			if save_game_res == null:
 				escoria.logger.report_warnings(
 					"esc_save_manager.gd",
@@ -90,7 +90,7 @@ func get_saves_list() -> Dictionary:
 					escoria.logger.report_warnings(
 						"esc_save_manager.gd",
 						[
-							"Savegame file %s contains valid data but doesn't match filename format %s. Skipping." 
+							"Savegame file %s contains valid data but doesn't match filename format %s. Skipping."
 							% [save_path, regex.get_pattern()]
 						]
 					)
@@ -154,9 +154,9 @@ func save_game_crash():
 	)
 	crash_savegame_filename = save_file_path.plus_file(
 		CRASH_SAVE_NAME_TEMPLATE % [
-			str(datetime["year"]) + str(datetime["month"]) 
+			str(datetime["year"]) + str(datetime["month"])
 					+ str(datetime["day"]),
-			str(datetime["hour"]) + str(datetime["minute"]) 
+			str(datetime["hour"]) + str(datetime["minute"])
 					+ str(datetime["second"])
 		]
 	)
@@ -165,22 +165,22 @@ func save_game_crash():
 	if error != OK:
 		escoria.logger.report_errors(
 			"esc_save_manager.gd",
-			["There was an issue writing the crash save to %s" 
+			["There was an issue writing the crash save to %s"
 				% crash_savegame_filename])
 	return error
 
 
-# Actual savegame function. 
+# Actual savegame function.
 #
 # ## Parameters
 # - p_savename: name of the savegame
 func _do_save_game(p_savename: String) -> ESCSaveGame:
 	var save_game = ESCSaveGame.new()
-	
+
 	var plugin_config = ConfigFile.new()
 	plugin_config.load("res://addons/escoria-core/plugin.cfg")
 	save_game.escoria_version = plugin_config.get_value("plugin", "version")
-	
+
 	save_game.game_version = escoria.project_settings_manager.get_setting(
 		escoria.project_settings_manager.GAME_VERSION
 	)
@@ -200,7 +200,7 @@ func _do_save_game(p_savename: String) -> ESCSaveGame:
 	escoria.object_manager.save_game(save_game)
 	escoria.main.save_game(save_game)
 	save_game.custom_data = escoria.game_scene.get_custom_data()
-	
+
 	return save_game
 
 
@@ -237,7 +237,7 @@ func load_game(id: int):
 			escoria_version,
 			"res://addons/escoria-core/game/core-scripts/migrations/versions"
 		)
-		
+
 	# Migrate savegame through game versions
 	if escoria.project_settings_manager.get_setting(
 			escoria.project_settings_manager.GAME_VERSION
@@ -291,7 +291,7 @@ func load_game(id: int):
 	load_statements.append(
 		ESCCommand.new("%s %s false" %
 				[
-					_change_scene.get_command_name(), 
+					_change_scene.get_command_name(),
 					save_game.main["current_scene_filename"]
 				]
 			)
@@ -303,8 +303,8 @@ func load_game(id: int):
 				save_game.objects[object_global_id].has("active"):
 			load_statements.append(ESCCommand.new("%s %s %s" \
 					% [
-						_set_active.get_command_name(), 
-						object_global_id, 
+						_set_active.get_command_name(),
+						object_global_id,
 						save_game.objects[object_global_id]["active"]
 					]
 				)
@@ -313,7 +313,7 @@ func load_game(id: int):
 		if save_game.objects[object_global_id].has("interactive"):
 			load_statements.append(ESCCommand.new("%s %s %s" \
 					% [
-						_set_interactive.get_command_name(), 
+						_set_interactive.get_command_name(),
 						object_global_id,
 						save_game.objects[object_global_id]["interactive"]
 					]
@@ -334,7 +334,7 @@ func load_game(id: int):
 			load_statements.append(ESCCommand.new("%s %s %s %s" \
 					% [
 						_teleport_pos.get_command_name(),
-						object_global_id, 
+						object_global_id,
 						int(save_game.objects[object_global_id] \
 							["global_transform"].origin.x),
 						int(save_game.objects[object_global_id] \
@@ -345,18 +345,18 @@ func load_game(id: int):
 			load_statements.append(ESCCommand.new("%s %s %s" \
 					% [
 						_set_angle.get_command_name(),
-						object_global_id, 
+						object_global_id,
 						save_game.objects[object_global_id]["last_deg"]
 					]
 				)
 			)
 
 		if object_global_id in [
-				escoria.object_manager.MUSIC, 
+				escoria.object_manager.MUSIC,
 				escoria.object_manager.SOUND, escoria.object_manager.SPEECH
 			]:
 			if save_game.objects[object_global_id]["state"] in [
-				"default", 
+				"default",
 				"off"
 			]:
 				load_statements.append(
@@ -400,7 +400,7 @@ func save_settings():
 	var settings_res := ESCSaveSettings.new()
 	var plugin_config = ConfigFile.new()
 	plugin_config.load("res://addons/escoria-core/plugin.cfg")
-	
+
 	settings_res.escoria_version = plugin_config.get_value("plugin", "version")
 	settings_res.text_lang = escoria.settings.text_lang
 	settings_res.voice_lang = escoria.settings.voice_lang

--- a/addons/escoria-core/game/core-scripts/save_data/esc_savegame.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_savegame.gd
@@ -22,10 +22,10 @@ export var date: String = ""
 # Main data to be saved
 export var main: Dictionary = {}
 
-# Escoria Global variables exported from ESCGlobalsManager 
+# Escoria Global variables exported from ESCGlobalsManager
 export var globals: Dictionary = {}
 
-# Escoria objects exported from ESCObjectsManager 
+# Escoria objects exported from ESCObjectsManager
 export var objects: Dictionary = {}
 
 # Custom data

--- a/addons/escoria-core/game/core-scripts/utils/esc_utils.gd
+++ b/addons/escoria-core/game/core-scripts/utils/esc_utils.gd
@@ -4,9 +4,9 @@ class_name ESCUtils
 
 
 # Convert radians to degrees
-# 
+#
 # #### Parameters
-# 
+#
 # - rad_angle: Angle in radians
 # **Returns** Degrees
 func get_deg_from_rad(rad_angle: float):
@@ -46,7 +46,7 @@ func get_typed_value(value: String, type_hint = []):
 	regex_float.compile("^[0-9]+\\.[0-9]+$")
 	var regex_int = RegEx.new()
 	regex_int.compile("^[0-9]+$")
-	
+
 	if regex_float.search(value):
 		return float(value)
 	elif regex_int.search(value):
@@ -74,7 +74,7 @@ func sanitize_whitespace(value: String) -> String:
 	var double_regex = RegEx.new()
 	double_regex.compile("\\s\\s+")
 	return double_regex.sub(
-		tab_regex.sub(value, " "), 
-		" ", 
+		tab_regex.sub(value, " "),
+		" ",
 		true
 	)

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -97,7 +97,7 @@ var save_manager: ESCSaveManager
 # The game scene loaded
 var game_scene: ESCGame
 
-# The compiled start script loaded from ProjectSettings 
+# The compiled start script loaded from ProjectSettings
 # escoria/main/game_start_script
 var start_script: ESCScript
 
@@ -120,11 +120,11 @@ func _init():
 	self.inputs_manager = ESCInputsManager.new()
 	self.room_manager = ESCRoomManager.new()
 	self.project_settings_manager = ESCProjectSettingsManager.new()
-	
+
 	settings = ESCSaveSettings.new()
-	
+
 	if self.project_settings_manager.get_setting(self.project_settings_manager.GAME_SCENE) == "":
-		logger.report_errors("escoria.gd", 
+		logger.report_errors("escoria.gd",
 			["Project setting '%s' is not set!" % self.project_settings_manager.GAME_SCENE]
 		)
 	else:
@@ -132,7 +132,7 @@ func _init():
 			self.project_settings_manager.get_setting(self.project_settings_manager.GAME_SCENE)
 		).instance()
 
-	print(get_script().get_path())	
+	print(get_script().get_path())
 
 
 # Load settings
@@ -142,7 +142,7 @@ func _ready():
 	room_manager.register_reserved_globals()
 	inputs_manager.register_core()
 	if self.project_settings_manager.get_setting(self.project_settings_manager.GAME_START_SCRIPT).empty():
-		logger.report_errors("escoria.gd", 
+		logger.report_errors("escoria.gd",
 		[
 			"Project setting '%s' is not set!" % self.project_settings_manager.GAME_START_SCRIPT
 		])
@@ -186,7 +186,7 @@ func apply_settings(p_settings: ESCSaveSettings) -> void:
 		settings = ESCSaveSettings.new()
 
 	AudioServer.set_bus_volume_db(
-		AudioServer.get_bus_index(BUS_MASTER), 
+		AudioServer.get_bus_index(BUS_MASTER),
 		linear2db(settings.master_volume)
 	)
 	AudioServer.set_bus_volume_db(
@@ -194,15 +194,15 @@ func apply_settings(p_settings: ESCSaveSettings) -> void:
 		linear2db(settings.sfx_volume)
 	)
 	AudioServer.set_bus_volume_db(
-		AudioServer.get_bus_index(BUS_MUSIC), 
+		AudioServer.get_bus_index(BUS_MUSIC),
 		linear2db(settings.music_volume)
-	)	
+	)
 	AudioServer.set_bus_volume_db(
-		AudioServer.get_bus_index(BUS_SPEECH), 
+		AudioServer.get_bus_index(BUS_SPEECH),
 		linear2db(settings.speech_volume)
 	)
 	TranslationServer.set_locale(settings.text_lang)
-	
+
 	game_scene.apply_custom_settings(settings.custom_settings)
 
 
@@ -214,7 +214,7 @@ func _input(event):
 
 	if event.is_action_pressed("ui_cancel"):
 		emit_signal("request_pause_menu")
-	
+
 
 # Pauses or unpause the game
 #
@@ -231,13 +231,13 @@ func set_game_paused(p_paused: bool):
 # Runs the event "event_name" from the "script" ESC script.
 #
 # #### Parameters
-# - script: ESC script containing the event to run. The script must have been 
+# - script: ESC script containing the event to run. The script must have been
 # loaded.
 # - event_name: Name of the event to run
 func run_event_from_script(script: ESCScript, event_name: String):
 	if script == null:
 		logger.report_errors(
-			"escoria.gd:run_event_from_script()", 
+			"escoria.gd:run_event_from_script()",
 			["Requested action %s on unloaded script %s" % [event_name, script],
 			"Please load the ESC script using esc_compiler.load_esc_file()."]
 		)
@@ -279,7 +279,7 @@ func register_ui(game_scene: String):
 		escoria.project_settings_manager.GAME_SCENE,
 		game_scene
 	)
-	
+
 
 # Deregister a user interface
 #
@@ -304,7 +304,7 @@ func deregister_ui(game_scene: String):
 		escoria.project_settings_manager.GAME_SCENE,
 		""
 	)
-	
+
 
 # Register a dialog manager addon. This should be called in a deferred way
 # from the addon's _enter_tree.
@@ -315,12 +315,12 @@ func register_dialog_manager(manager_class: String):
 	var dialog_managers: Array = escoria.project_settings_manager.get_setting(
 		escoria.project_settings_manager.DIALOG_MANAGERS
 	)
-	
+
 	if manager_class in dialog_managers:
 		return
-		
+
 	dialog_managers.push_back(manager_class)
-	
+
 	escoria.project_settings_manager.set_setting(
 		escoria.project_settings_manager.DIALOG_MANAGERS,
 		dialog_managers
@@ -335,7 +335,7 @@ func deregister_dialog_manager(manager_class: String):
 	var dialog_managers: Array = escoria.project_settings_manager.get_setting(
 		escoria.project_settings_manager.DIALOG_MANAGERS
 	)
-	
+
 	if not manager_class in dialog_managers:
 		logger.report_warnings(
 			"escoria.gd:deregister_dialog_manager()",
@@ -344,9 +344,9 @@ func deregister_dialog_manager(manager_class: String):
 			]
 		)
 		return
-	
+
 	dialog_managers.erase(manager_class)
-	
+
 	escoria.project_settings_manager.set_setting(
 		escoria.project_settings_manager.DIALOG_MANAGERS,
 		dialog_managers

--- a/addons/escoria-core/game/inputs_manager.gd
+++ b/addons/escoria-core/game/inputs_manager.gd
@@ -44,47 +44,47 @@ func register_core():
 # Connect the item signals to the local methods
 func register_inventory_item(item: Node):
 	item.connect(
-		"mouse_left_inventory_item", 
-		self, 
+		"mouse_left_inventory_item",
+		self,
 		"_on_mouse_left_click_inventory_item"
 	)
 	item.connect(
-		"mouse_double_left_inventory_item", 
-		self, 
+		"mouse_double_left_inventory_item",
+		self,
 		"_on_mouse_double_left_click_inventory_item"
 	)
 	item.connect(
-		"mouse_right_inventory_item", 
+		"mouse_right_inventory_item",
 		self,
 		"_on_mouse_right_click_inventory_item"
 	)
-	
+
 	item.connect(
-		"inventory_item_focused", 
-		self, 
+		"inventory_item_focused",
+		self,
 		"_on_mouse_entered_inventory_item"
 	)
 	item.connect(
-		"inventory_item_unfocused", 
-		self, 
+		"inventory_item_unfocused",
+		self,
 		"_on_mouse_exited_inventory_item"
 	)
-	
+
 
 func register_background(background: ESCBackground):
 	background.connect(
-		"left_click_on_bg", 
-		self, 
+		"left_click_on_bg",
+		self,
 		"_on_left_click_on_bg"
 	)
 	background.connect(
-		"right_click_on_bg", 
-		escoria.inputs_manager, 
+		"right_click_on_bg",
+		escoria.inputs_manager,
 		"_on_right_click_on_bg"
 	)
 	background.connect(
-		"double_left_click_on_bg", 
-		escoria.inputs_manager, 
+		"double_left_click_on_bg",
+		escoria.inputs_manager,
 		"_on_double_left_click_on_bg"
 	)
 	background.connect(
@@ -99,8 +99,8 @@ func register_background(background: ESCBackground):
 		"_on_mousewheel_action",
 		[-1]
 	)
-	
-	
+
+
 # Clear the stack of hovered items
 func clear_stack():
 	hover_stack = []
@@ -144,18 +144,18 @@ func _on_right_click_on_bg(position: Vector2) -> void:
 # An inventory item was clicked with the LMB
 #
 # #### Parameters
-# 
+#
 # - inventory_item_global_id: The global id of the clicked inventory item
 # - event: The input event received
 func _on_mouse_left_click_inventory_item(
-	inventory_item_global_id: String, 
+	inventory_item_global_id: String,
 	event: InputEvent
 ) -> void:
 	escoria.logger.info(
 		"Inventory item left clicked %s " % inventory_item_global_id
 	)
 	escoria.main.current_scene.game.left_click_on_inventory_item(
-		inventory_item_global_id, 
+		inventory_item_global_id,
 		event
 	)
 
@@ -167,7 +167,7 @@ func _on_mouse_left_click_inventory_item(
 # - inventory_item_global_id: The global id of the clicked inventory item
 # - event: The input event received
 func _on_mouse_right_click_inventory_item(
-	inventory_item_global_id: String, 
+	inventory_item_global_id: String,
 	event: InputEvent
 ) -> void:
 	if input_mode == INPUT_ALL:
@@ -175,7 +175,7 @@ func _on_mouse_right_click_inventory_item(
 			"Inventory item right clicked %s" % inventory_item_global_id
 		)
 		escoria.main.current_scene.game.right_click_on_inventory_item(
-			inventory_item_global_id, 
+			inventory_item_global_id,
 			event
 		)
 
@@ -183,11 +183,11 @@ func _on_mouse_right_click_inventory_item(
 # An inventory item was doublce-clicked with the LMB
 #
 # #### Parameters
-# 
+#
 # - inventory_item_global_id: The global id of the clicked inventory item
 # - event: The input event received
 func _on_mouse_double_left_click_inventory_item(
-	inventory_item_global_id: String, 
+	inventory_item_global_id: String,
 	event: InputEvent
 ) -> void:
 	if input_mode == INPUT_ALL:
@@ -195,7 +195,7 @@ func _on_mouse_double_left_click_inventory_item(
 			"Inventory item double left clicked %s" % inventory_item_global_id
 		)
 		escoria.main.current_scene.game.left_double_click_on_inventory_item(
-			inventory_item_global_id, 
+			inventory_item_global_id,
 			event
 		)
 
@@ -204,7 +204,7 @@ func _on_mouse_double_left_click_inventory_item(
 #
 # #### Parameters
 #
-# - inventory_item_global_id: The global id of the inventory item 
+# - inventory_item_global_id: The global id of the inventory item
 #	that is hovered
 func _on_mouse_entered_inventory_item(inventory_item_global_id: String) -> void:
 	escoria.logger.info(
@@ -229,7 +229,7 @@ func _on_mouse_exited_inventory_item() -> void:
 func _on_mouse_entered_item(item: ESCItem) -> void:
 	escoria.logger.info("Item focused: ", [item.global_id])
 	_clean_hover_stack()
-	
+
 	if not hover_stack.empty():
 		if item.z_index < hover_stack.back().z_index:
 			hover_stack.insert(hover_stack.size() - 1, item)
@@ -237,7 +237,7 @@ func _on_mouse_entered_item(item: ESCItem) -> void:
 			hover_stack.push_back(item)
 	else:
 		hover_stack.push_back(item)
-	
+
 	hotspot_focused = hover_stack.back().global_id
 	escoria.main.current_scene.game.element_focused(item.global_id)
 
@@ -256,7 +256,7 @@ func _on_mouse_exited_item(item: ESCItem) -> void:
 	else:
 		hotspot_focused = hover_stack.back().global_id
 		escoria.main.current_scene.game.element_focused(hotspot_focused)
-	
+
 
 # An Escoria item was clicked with the LMB
 #
@@ -270,7 +270,7 @@ func _on_mouse_left_clicked_item(item: ESCItem, event: InputEvent) -> void:
 			escoria.logger.info("Item left clicked", [item.global_id, event])
 			hotspot_focused = item.global_id
 			escoria.main.current_scene.game.left_click_on_item(
-				item.global_id, 
+				item.global_id,
 				event
 			)
 
@@ -289,7 +289,7 @@ func _on_mouse_left_double_clicked_item(
 		escoria.logger.info("Item left double clicked", [item.global_id, event])
 		hotspot_focused = item.global_id
 		escoria.main.current_scene.game.left_double_click_on_item(
-			item.global_id, 
+			item.global_id,
 			event
 		)
 
@@ -305,7 +305,7 @@ func _on_mouse_right_clicked_item(item: ESCItem, event: InputEvent) -> void:
 		escoria.logger.info("Item right clicked", [item.global_id, event])
 		hotspot_focused = item.global_id
 		escoria.main.current_scene.game.right_click_on_item(
-			item.global_id, 
+			item.global_id,
 			event
 		)
 
@@ -313,7 +313,7 @@ func _on_mouse_right_clicked_item(item: ESCItem, event: InputEvent) -> void:
 # The mousewheel was turned
 #
 # #### Parameters
-# 
+#
 # - direction: The direction the wheel was turned. 1 = up, -1 = down
 func _on_mousewheel_action(direction: int):
 	escoria.main.current_scene.game.mousewheel_action(direction)

--- a/addons/escoria-core/game/main.gd
+++ b/addons/escoria-core/game/main.gd
@@ -36,18 +36,18 @@ func _ready() -> void:
 func set_scene(p_scene: Node) -> void:
 	if !p_scene:
 		escoria.logger.report_errors("main", ["Trying to set empty scene"])
-	
+
 	if current_scene != null:
 		clear_scene()
 
 	if not p_scene.is_inside_tree():
-		add_child(p_scene) 
+		add_child(p_scene)
 		move_child(p_scene, 0)
 	current_scene = p_scene
 	check_game_scene_methods()
 
 	set_camera_limits()
-	
+
 	emit_signal("room_ready")
 
 
@@ -58,12 +58,12 @@ func clear_scene() -> void:
 
 	escoria.action_manager.clear_current_action()
 	escoria.action_manager.clear_current_tool()
-	
+
 	if escoria.game_scene.get_parent() == current_scene:
 		current_scene.remove_child(escoria.game_scene)
-		
+
 	current_scene.get_parent().remove_child(current_scene)
-	
+
 	current_scene.queue_free()
 	current_scene = null
 
@@ -88,7 +88,7 @@ func set_camera_limits(camera_limit_id: int = 0) -> void:
 				area = child.get_full_area_rect2()
 				break
 
-		# if the background is smaller than the viewport, we want the camera 
+		# if the background is smaller than the viewport, we want the camera
 		# to stick centered on the background
 		if area.size.x == 0 or area.size.y == 0 \
 				or area.size < get_viewport().size:
@@ -117,7 +117,7 @@ func set_camera_limits(camera_limit_id: int = 0) -> void:
 					scene_camera_limits.size.y
 		)
 		escoria.logger.info(
-			"Setting camera limits from parameter ", 
+			"Setting camera limits from parameter ",
 			[scene_camera_limits]
 		)
 
@@ -142,27 +142,27 @@ func check_game_scene_methods():
 	assert(current_scene.game.has_method("left_click_on_bg"))
 	assert(current_scene.game.has_method("right_click_on_bg"))
 	assert(current_scene.game.has_method("left_double_click_on_bg"))
-	
+
 	assert(current_scene.game.has_method("element_focused"))
 	assert(current_scene.game.has_method("element_unfocused"))
-	
+
 	assert(current_scene.game.has_method("left_click_on_item"))
 	assert(current_scene.game.has_method("right_click_on_item"))
 	assert(current_scene.game.has_method("left_double_click_on_item"))
-	
+
 	assert(current_scene.game.has_method("open_inventory"))
 	assert(current_scene.game.has_method("close_inventory"))
-	
+
 	assert(current_scene.game.has_method("left_click_on_inventory_item"))
 	assert(current_scene.game.has_method("right_click_on_inventory_item"))
 	assert(current_scene.game.has_method("left_double_click_on_inventory_item"))
-	
+
 	assert(current_scene.game.has_method("inventory_item_focused"))
 	assert(current_scene.game.has_method("inventory_item_unfocused"))
-	
+
 	assert(current_scene.game.has_method("mousewheel_action"))
-	
+
 	assert(current_scene.game.has_method("hide_ui"))
 	assert(current_scene.game.has_method("show_ui"))
 	assert(current_scene.game.has_method("_on_event_done"))
-	
+

--- a/addons/escoria-core/game/main_scene.gd
+++ b/addons/escoria-core/game/main_scene.gd
@@ -1,4 +1,4 @@
-# Main_scene is the entry point for Godot Engine. 
+# Main_scene is the entry point for Godot Engine.
 # This scene sets up the main menu scene to load.
 extends Node
 
@@ -6,4 +6,4 @@ extends Node
 # Start the main menu
 func _ready():
 	escoria.init()
-	
+

--- a/addons/escoria-core/game/project_settings_manager.gd
+++ b/addons/escoria-core/game/project_settings_manager.gd
@@ -95,7 +95,7 @@ func register_setting(name: String, default, info: Dictionary) -> void:
 # *Returns* the value of the project setting located with key.
 func get_setting(key: String):
 	if not ProjectSettings.has_setting(key):
-		escoria.logger.report_errors("project_settings_manager.gd", 
+		escoria.logger.report_errors("project_settings_manager.gd",
 			["Parameter %s is not set!" % key]
 		)
 

--- a/addons/escoria-core/game/scenes/camera_player/esc_camera.gd
+++ b/addons/escoria-core/game/scenes/camera_player/esc_camera.gd
@@ -56,10 +56,10 @@ func _resolve_target_and_zoom(p_target) -> void:
 	_target = Vector2()
 	_zoom_target = Vector2()
 	_follow_target = null
-	
+
 	if p_target is Node and "is_movable" in p_target and p_target.is_movable:
 		_follow_target = p_target
-	
+
 	if p_target is Vector2:
 		_target = p_target
 	elif p_target is Array and p_target.size() > 0:
@@ -90,9 +90,9 @@ func set_drag_margin_enabled(p_dm_h_enabled, p_dm_v_enabled):
 # - p_speed: Number of seconds for the camera to reach the target
 func set_target(p_target, p_speed : float = 0.0):
 	var speed = p_speed
-	
+
 	_resolve_target_and_zoom(p_target)
-	
+
 	escoria.logger.info(
 		"Current camera position = %s " % str(self.global_position)
 	)
@@ -104,7 +104,7 @@ func set_target(p_target, p_speed : float = 0.0):
 
 		if _tween.is_active():
 			escoria.logger.report_warnings(
-				"esc_camera.gd:set_target()", 
+				"esc_camera.gd:set_target()",
 				[
 					"Tween is still active: %f/%f" % [
 						_tween.tell(),
@@ -115,12 +115,12 @@ func set_target(p_target, p_speed : float = 0.0):
 			_tween.emit_signal("tween_completed")
 
 		_tween.interpolate_property(
-			self, 
-			"global_position", 
-			self.global_position, 
-			_target, 
-			time, 
-			Tween.TRANS_LINEAR, 
+			self,
+			"global_position",
+			self.global_position,
+			_target,
+			time,
+			Tween.TRANS_LINEAR,
 			Tween.EASE_IN_OUT
 		)
 		_tween.start()
@@ -134,7 +134,7 @@ func set_target(p_target, p_speed : float = 0.0):
 func set_camera_zoom(p_zoom_level: float, p_time: float):
 	if p_zoom_level <= 0.0:
 		escoria.logger.report_errors(
-			"esc_camera.gd:set_camera_zoom()", 
+			"esc_camera.gd:set_camera_zoom()",
 			["Tried to set negative or zero zoom level"]
 		)
 
@@ -145,7 +145,7 @@ func set_camera_zoom(p_zoom_level: float, p_time: float):
 	else:
 		if _tween.is_active():
 			escoria.logger.report_warnings(
-				"esc_camera.gd:set_camera_zoom()", 
+				"esc_camera.gd:set_camera_zoom()",
 				[
 					"Tween is still active: %f/%f" % [
 						_tween.tell(),
@@ -156,12 +156,12 @@ func set_camera_zoom(p_zoom_level: float, p_time: float):
 			_tween.emit_signal("tween_completed")
 
 		_tween.interpolate_property(
-			self, 
-			"zoom", 
-			self.zoom, 
-			_zoom_target, 
-			p_time, 
-			Tween.TRANS_LINEAR, 
+			self,
+			"zoom",
+			self.zoom,
+			_zoom_target,
+			p_time,
+			Tween.TRANS_LINEAR,
 			Tween.EASE_IN_OUT
 		)
 		_tween.start()
@@ -169,18 +169,18 @@ func set_camera_zoom(p_zoom_level: float, p_time: float):
 
 # Push the camera towards the target in terms of position and zoom level
 # using a given transition type and time.
-# See 
+# See
 # https://docs.godotengine.org/en/stable/classes/class_tween.html#enumerations
 #
 # #### Parameters
 # - p_target: Target to push to
 # - p_time: Number of seconds for the transition to take
-# - p_type: Tween transition type 
+# - p_type: Tween transition type
 func push(p_target, p_time: float = 0.0, p_type: int = 0):
 	_resolve_target_and_zoom(p_target)
-	
+
 	var push_target = null
-	
+
 	if _follow_target != null:
 		push_target = p_target.position
 	else:
@@ -193,7 +193,7 @@ func push(p_target, p_time: float = 0.0, p_type: int = 0):
 	else:
 		if _tween.is_active():
 			escoria.logger.report_warnings(
-				"esc_camera.gd:push()", 
+				"esc_camera.gd:push()",
 				[
 					"Tween is still active:" % [
 						_tween.tell(),
@@ -205,32 +205,32 @@ func push(p_target, p_time: float = 0.0, p_type: int = 0):
 
 		if _zoom_target != Vector2():
 			_tween.interpolate_property(
-				self, 
-				"zoom", 
-				self.zoom, 
-				_zoom_target, 
-				p_time, 
-				p_type, 
+				self,
+				"zoom",
+				self.zoom,
+				_zoom_target,
+				p_time,
+				p_type,
 				Tween.EASE_IN_OUT
 			)
 
 		_tween.interpolate_property(
-			self, 
-			"global_position", 
-			self.global_position, 
-			push_target, 
-			p_time, 
+			self,
+			"global_position",
+			self.global_position,
+			push_target,
+			p_time,
 			p_type,
 			Tween.EASE_IN_OUT
 		)
-		
+
 		_tween.start()
 
 
 # Shift the camera by the given vector in a given time and using a specific
 # Tween transition type.
 #
-# See 
+# See
 # https://docs.godotengine.org/en/stable/classes/class_tween.html#enumerations
 #
 # #### Parameters
@@ -245,7 +245,7 @@ func shift(p_target: Vector2, p_time: float, p_type: int):
 
 	if _tween.is_active():
 		escoria.logger.report_warnings(
-				"esc_camera.gd:set_camera_zoom()", 
+				"esc_camera.gd:set_camera_zoom()",
 				[
 					"Tween is still active: %f/%f" % [
 						_tween.tell(),
@@ -254,14 +254,14 @@ func shift(p_target: Vector2, p_time: float, p_type: int):
 				]
 			)
 		_tween.emit_signal("tween_completed")
-	
+
 	_tween.interpolate_property(
-		self, 
-		"global_position", 
-		self.global_position, 
-		new_pos, 
-		p_time, 
-		p_type, 
+		self,
+		"global_position",
+		self.global_position,
+		new_pos,
+		p_time,
+		p_type,
 		Tween.EASE_IN_OUT
 	)
 	_tween.start()

--- a/addons/escoria-core/game/scenes/camera_player/esc_camera_limits.gd
+++ b/addons/escoria-core/game/scenes/camera_player/esc_camera_limits.gd
@@ -17,9 +17,9 @@ var limit_bottom: int = 10000
 
 
 func _init(
-	left: int, 
-	right: int, 
-	top: int, 
+	left: int,
+	right: int,
+	top: int,
 	bottom: int
 ):
 	limit_left = left

--- a/addons/escoria-core/game/scenes/dialogs/esc_dialog_manager.gd
+++ b/addons/escoria-core/game/scenes/dialogs/esc_dialog_manager.gd
@@ -6,7 +6,7 @@ class_name ESCDialogManager
 # Emitted when the say function has completed showing the text
 signal say_finished
 
-# Emitted when the player has chosen an option 
+# Emitted when the player has chosen an option
 signal option_chosen(option)
 
 
@@ -18,7 +18,7 @@ signal option_chosen(option)
 # *Returns* Wether the type is supported or not
 func has_type(type: String) -> bool:
 	return false
-	
+
 
 # Check wether a specific chooser type is supported by the
 # dialog plugin
@@ -56,7 +56,7 @@ func choose(dialog_player: Node, dialog: ESCDialog):
 # Trigger running the dialog faster
 func speedup():
 	pass
-	
+
 
 # The say command has been interrupted, cancel the dialog display
 func interrupt():

--- a/addons/escoria-core/game/scenes/dialogs/esc_dialog_player.gd
+++ b/addons/escoria-core/game/scenes/dialogs/esc_dialog_player.gd
@@ -8,7 +8,7 @@ const KEYTEXT_REGEX = "^((?<key>[^:]+):)?\"(?<text>.+)\""
 
 
 # Emitted when an answer as chosem
-# 
+#
 # ##### Parameters
 #
 # - option: The dialog option that was chosen
@@ -46,7 +46,7 @@ func _input(event):
 	if event is InputEventMouseButton and event.pressed and is_speaking:
 		speedup()
 		get_tree().set_input_as_handled()
-		
+
 
 # Find the matching voice output file for the given key
 #
@@ -57,7 +57,7 @@ func _input(event):
 #
 # *Returns* The path to the matching voice file
 func _get_voice_file(key: String, start: String = "") -> String:
-	if start == "":		
+	if start == "":
 		start = escoria.project_settings_manager.get_setting(
 			escoria.project_settings_manager.SPEECH_FOLDER
 		)
@@ -68,14 +68,14 @@ func _get_voice_file(key: String, start: String = "") -> String:
 		while file_name != "":
 			if _dir.current_is_dir():
 				var _voice_file = _get_voice_file(
-					key, 
+					key,
 					start.plus_file(file_name)
 				)
 				if _voice_file != "":
 					return _voice_file
 			else:
 				if file_name == "%s.%s.import" % [
-					key, 
+					key,
 					escoria.project_settings_manager.get_setting(
 						escoria.project_settings_manager.SPEECH_EXTENSION
 					)
@@ -93,11 +93,11 @@ func _get_voice_file(key: String, start: String = "") -> String:
 # - type: UI to use for the dialog
 # - text: Text to say
 func say(character: String, type: String, text: String) -> void:
-	if type == "":		
+	if type == "":
 		type = escoria.project_settings_manager.get_setting(
 			escoria.project_settings_manager.DEFAULT_DIALOG_TYPE
 		)
-	is_speaking = true	
+	is_speaking = true
 	for _manager_class in escoria.project_settings_manager.get_setting(
 		escoria.project_settings_manager.DIALOG_MANAGERS
 	):
@@ -105,7 +105,7 @@ func say(character: String, type: String, text: String) -> void:
 			var _manager: ESCDialogManager = load(_manager_class).new()
 			if _manager.has_type(type):
 				_dialog_manager = _manager
-	
+
 	if _dialog_manager == null:
 		escoria.logger.report_errors(
 			"esc_dialog_player.gd:say",
@@ -113,9 +113,9 @@ func say(character: String, type: String, text: String) -> void:
 				"No dialog manager supports the type %s" % type
 			]
 		)
-	
+
 	_dialog_manager.connect("say_finished", self, "_on_say_finished", [], CONNECT_ONESHOT)
-	
+
 	var matches = _keytext_regex.search(text)
 	if not matches:
 		escoria.logger.report_errors(
@@ -137,7 +137,7 @@ func say(character: String, type: String, text: String) -> void:
 		text = tr(matches.get_string("key"))
 	else:
 		text = matches.get_string("text")
-	
+
 	_dialog_manager.say(self, character, text, type)
 
 
@@ -163,12 +163,12 @@ func speedup() -> void:
 func start_dialog_choices(dialog: ESCDialog, type: String = "simple"):
 	if dialog.options.empty():
 		escoria.logger.report_errors(
-			"esc_dialog_player.gd:start_dialog_choices()", 
+			"esc_dialog_player.gd:start_dialog_choices()",
 			["Received answers array was empty."]
 		)
-	
+
 	var _dialog_chooser_ui: ESCDialogManager = null
-	
+
 	for _manager_class in escoria.project_settings_manager.get_setting(
 		escoria.project_settings_manager.DIALOG_MANAGERS
 	):
@@ -176,7 +176,7 @@ func start_dialog_choices(dialog: ESCDialog, type: String = "simple"):
 			var _manager: ESCDialogManager = load(_manager_class).new()
 			if _manager.has_chooser_type(type):
 				_dialog_chooser_ui = _manager
-	
+
 	if _dialog_chooser_ui == null:
 		escoria.logger.report_errors(
 			"esc_dialog_player.gd: Unknown chooser type",
@@ -184,7 +184,7 @@ func start_dialog_choices(dialog: ESCDialog, type: String = "simple"):
 				"No dialog manager supports the chooser type %s" % type
 			]
 		)
-	
+
 	_dialog_chooser_ui.choose(self, dialog)
 	var option = yield(_dialog_chooser_ui, "option_chosen")
 	emit_signal("option_chosen", option)

--- a/addons/escoria-core/game/scenes/esc_prompt/esc_prompt_popup.gd
+++ b/addons/escoria-core/game/scenes/esc_prompt/esc_prompt_popup.gd
@@ -24,18 +24,18 @@ func _ready() -> void:
 func _on_command_text_entered(p_command_str : String):
 	if p_command_str.empty():
 		return
-	
+
 	command.text = ""
 	past_actions.text += "\n"
 	past_actions.text += "# " + p_command_str
 	past_actions.text += "\n"
-	
+
 	var errors = []
 	var script = escoria.esc_compiler.compile([
 		"%s%s" % [ESCEvent.PREFIX, _debug.get_command_name()],
 		p_command_str
 	])
-	
+
 	if script:
 		escoria.event_manager.queue_event(script.events[escoria.event_manager.EVENT_DEBUG])
 		var ret = yield(escoria.event_manager, "event_finished")

--- a/addons/escoria-core/game/scenes/inventory/inventory_ui.gd
+++ b/addons/escoria-core/game/scenes/inventory/inventory_ui.gd
@@ -4,7 +4,7 @@ extends Control
 class_name ESCInventory
 
 
-# Define the actual container node to add items as children of. 
+# Define the actual container node to add items as children of.
 # Should be a Container.
 export(NodePath) var inventory_ui_container
 
@@ -18,19 +18,19 @@ var items_ids_in_inventory: Dictionary = {}
 func _ready():
 	if inventory_ui_container == null or inventory_ui_container.is_empty():
 		escoria.logger.report_errors(
-			self.get_path(), 
+			self.get_path(),
 			["Items container is empty."]
 		)
 		return
-		
+
 	for item_id in escoria.inventory_manager.items_in_inventory():
 		call_deferred("add_new_item_by_id", item_id)
-		
+
 	escoria.inventory = self
-	
+
 	escoria.globals_manager.connect(
 		"global_changed", #
-		self, 
+		self,
 		"_on_escoria_global_changed"
 	)
 
@@ -63,25 +63,25 @@ func add_new_item_by_id(item_id: String) -> void:
 						"Item global id '%s' does not exist." % item_id
 					]
 				)
-				
+
 		var inventory_item = ESCInventoryItem.new(
 			escoria.object_manager.get_object(item_id).node
 		)
 		var inventory_item_button = get_node(
 			inventory_ui_container
 		).add_item(inventory_item)
-		
+
 		items_ids_in_inventory[item_id] = inventory_item
-		
+
 		if not escoria.object_manager.has(item_id):
 			escoria.object_manager.register_object(
 				ESCObject.new(
-					item_id, 
+					item_id,
 					inventory_item_button
 				),
 				true
 			)
-		
+
 		escoria.inputs_manager.register_inventory_item(inventory_item_button)
 
 
@@ -89,58 +89,58 @@ func add_new_item_by_id(item_id: String) -> void:
 func remove_item_by_id(item_id: String) -> void:
 	if items_ids_in_inventory.has(item_id):
 		var item_inventory_button = items_ids_in_inventory[item_id]
-		
+
 		if item_inventory_button.is_connected(
-			"mouse_left_inventory_item", 
-			escoria.inputs_manager, 
+			"mouse_left_inventory_item",
+			escoria.inputs_manager,
 			"_on_mouse_left_click_inventory_item"
 		):
 			item_inventory_button.disconnect(
-				"mouse_left_inventory_item", 
-				escoria.inputs_manager, 
+				"mouse_left_inventory_item",
+				escoria.inputs_manager,
 				"_on_mouse_left_click_inventory_item"
 			)
 		if item_inventory_button.is_connected(
-			"mouse_double_left_inventory_item", 
-			escoria.inputs_manager, 
+			"mouse_double_left_inventory_item",
+			escoria.inputs_manager,
 			"_on_mouse_double_left_click_inventory_item"
 		):
 			item_inventory_button.disconnect(
-				"mouse_double_left_inventory_item", 
-				escoria.inputs_manager, 
+				"mouse_double_left_inventory_item",
+				escoria.inputs_manager,
 				"_on_mouse_double_left_click_inventory_item"
 			)
 		if item_inventory_button.is_connected(
-			"mouse_right_inventory_item", 
-			escoria.inputs_manager, 
+			"mouse_right_inventory_item",
+			escoria.inputs_manager,
 			"_on_mouse_right_click_inventory_item"
 		):
 			item_inventory_button.disconnect(
-				"mouse_right_inventory_item", 
-				escoria.inputs_manager, 
+				"mouse_right_inventory_item",
+				escoria.inputs_manager,
 				"_on_mouse_right_click_inventory_item"
 			)
 		if item_inventory_button.is_connected(
-			"inventory_item_focused", 
-			escoria.inputs_manager, 
+			"inventory_item_focused",
+			escoria.inputs_manager,
 			"_on_mouse_entered_inventory_item"
 		):
 			item_inventory_button.disconnect(
-				"inventory_item_focused", 
-				escoria.inputs_manager, 
+				"inventory_item_focused",
+				escoria.inputs_manager,
 				"_on_mouse_entered_inventory_item"
 			)
 		if item_inventory_button.is_connected(
-			"inventory_item_unfocused", 
-			escoria.inputs_manager, 
+			"inventory_item_unfocused",
+			escoria.inputs_manager,
 			"_on_mouse_exited_inventory_item"
 		):
 			item_inventory_button.disconnect(
-				"inventory_item_unfocused", 
-				escoria.inputs_manager, 
+				"inventory_item_unfocused",
+				escoria.inputs_manager,
 				"_on_mouse_exited_inventory_item"
 			)
-		
+
 		get_node(inventory_ui_container).remove_item(item_inventory_button)
 		items_ids_in_inventory.erase(item_id)
 
@@ -148,7 +148,7 @@ func remove_item_by_id(item_id: String) -> void:
 # React to changes to inventory globals adding items or removing them
 func _on_escoria_global_changed(global: String, old_value, new_value) -> void:
 	if !global.begins_with("i/"):
-		return 
+		return
 	var item = global.rsplit("i/", false)
 	if item.size() == 1:
 		if new_value:
@@ -157,9 +157,9 @@ func _on_escoria_global_changed(global: String, old_value, new_value) -> void:
 			remove_item_by_id(item[0])
 	else:
 		escoria.logger.report_errors(
-			"inventory_ui.gd:_on_escoria_global_changed()", 
+			"inventory_ui.gd:_on_escoria_global_changed()",
 			[
-				"Global must contain only one item name.", 
+				"Global must contain only one item name.",
 				"(received: %s)" % global
 			]
 		)

--- a/addons/escoria-core/game/scenes/sound/esc_sound_player.gd
+++ b/addons/escoria-core/game/scenes/sound/esc_sound_player.gd
@@ -42,7 +42,7 @@ func set_state(p_state: String, p_force: bool = false):
 		if resource is AudioStreamSample:
 			resource.loop_mode = AudioStreamSample.LOOP_DISABLED
 		elif "loop" in resource:
-			resource.loop = false			
+			resource.loop = false
 		if escoria.project_settings_manager.has_setting(escoria.project_settings_manager.SFX_VOLUME):
 			stream.volume_db = escoria.project_settings_manager.get_setting(
 				escoria.project_settings_manager.SFX_VOLUME

--- a/addons/escoria-core/game/scenes/transitions/esc_transition_player.gd
+++ b/addons/escoria-core/game/scenes/transitions/esc_transition_player.gd
@@ -5,7 +5,7 @@ class_name ESCTransitionPlayer
 # Emitted when the transition was played
 signal transition_done(transition_id)
 
-# Id of the transition. Allows keeping track of the actual transition 
+# Id of the transition. Allows keeping track of the actual transition
 # being played or finished
 var transition_id: int = 0
 
@@ -34,20 +34,20 @@ func _ready() -> void:
 	_tween = Tween.new()
 	add_child(_tween)
 	_tween.connect("tween_all_completed", self, "_on_tween_completed")
-	
+
 	transition()
 
 
 # Play a transition animation
 #
 # ## Parameters
-# 
+#
 # - transition_name: name of the transition to play (if empty string, uses
 # the default transition)
 # - mode: Mode to transition (in/out)
 # - duration: The duration the transition should take
 func transition(
-	transition_name: String = "", 
+	transition_name: String = "",
 	mode: int = TRANSITION_MODE.IN,
 	duration: float = 1.0
 ) -> int:
@@ -56,23 +56,23 @@ func transition(
 			"transition: Transition %s not found" % transition_name,
 			[]
 		)
-	
+
 	material = ResourceLoader.load(get_transition(transition_name))
 	transition_id += 1
-	
+
 	var start = 0.0
 	var end = 1.0
-	
+
 	if mode == TRANSITION_MODE.OUT:
 		start = 1.0
 		end = 0.0
-	
+
 	if _tween.is_active():
 		_was_canceled = true
 		_tween.stop_all()
 		_tween.remove_all()
 		emit_signal("transition_done", transition_id-1)
-	
+
 	_tween.interpolate_property(
 		$".",
 		"material:shader_param/cutoff",
@@ -105,7 +105,7 @@ func get_transition(name: String) -> String:
 	return ""
 
 
-# Returns true whether the transition scene has a transition corresponding 
+# Returns true whether the transition scene has a transition corresponding
 # to name provided.
 #
 # ## Parameters
@@ -115,7 +115,7 @@ func get_transition(name: String) -> String:
 # *Returns* true if a transition exists with given name.
 func has_transition(name: String) -> bool:
 	return not get_transition(name) == ""
-	
+
 
 func _on_tween_completed():
 	if not _was_canceled:

--- a/addons/escoria-core/plugin.gd
+++ b/addons/escoria-core/plugin.gd
@@ -6,25 +6,25 @@ extends EditorPlugin
 # Setup Escoria
 func _enter_tree():
 	add_autoload_singleton(
-		"escoria", 
+		"escoria",
 		"res://addons/escoria-core/game/escoria.tscn"
 	)
-	
+
 	# Add input actions in InputMap
 	InputMap.add_action(escoria.inputs_manager.SWITCH_ACTION_VERB)
 	InputMap.add_action(escoria.inputs_manager.ESC_SHOW_DEBUG_PROMPT)
-	
+
 	# Define standard settings
 	ProjectSettings.set_setting(
-		"application/run/main_scene", 
+		"application/run/main_scene",
 		"res://addons/escoria-core/game/main_scene.tscn"
 	)
-	
+
 	ProjectSettings.set_setting(
-		"audio/default_bus_layout", 
+		"audio/default_bus_layout",
 		"res://addons/escoria-core/default_bus_layout.tres"
 	)
-	
+
 
 func _ready():
 	# Prepare settings
@@ -45,7 +45,7 @@ func set_escoria_ui_settings():
 			"type": TYPE_STRING
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.GAME_SCENE,
 		"",
@@ -56,7 +56,7 @@ func set_escoria_ui_settings():
 			"hint_string": "*.tscn, *.scn"
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.ITEMS_AUTOREGISTER_PATH,
 		"res://game/items/escitems/",
@@ -66,7 +66,7 @@ func set_escoria_ui_settings():
 			"hint": PROPERTY_HINT_DIR
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.DEFAULT_TRANISITION,
 		"curtain",
@@ -75,7 +75,7 @@ func set_escoria_ui_settings():
 			"type": TYPE_STRING
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.TRANSITION_PATHS,
 		[
@@ -87,7 +87,7 @@ func set_escoria_ui_settings():
 			"hint": PROPERTY_HINT_DIR
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.INVENTORY_ITEM_SIZE,
 		Vector2(72, 72),
@@ -96,7 +96,7 @@ func set_escoria_ui_settings():
 			"type": TYPE_VECTOR2
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.DIALOG_MANAGERS,
 		[],
@@ -115,7 +115,7 @@ func set_escoria_main_settings():
 			"type": TYPE_STRING
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.GAME_START_SCRIPT,
 		"",
@@ -125,7 +125,7 @@ func set_escoria_main_settings():
 			"hint_string": "*.esc"
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.FORCE_QUIT,
 		true,
@@ -133,7 +133,7 @@ func set_escoria_main_settings():
 			"type": TYPE_BOOL
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.COMMAND_DIRECTORIES,
 		[
@@ -143,7 +143,7 @@ func set_escoria_main_settings():
 			"type": TYPE_ARRAY,
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.TEXT_LANG,
 		TranslationServer.get_locale(),
@@ -152,7 +152,7 @@ func set_escoria_main_settings():
 			"hint": PROPERTY_HINT_NONE
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.VOICE_LANG,
 		TranslationServer.get_locale(),
@@ -161,7 +161,7 @@ func set_escoria_main_settings():
 			"hint": PROPERTY_HINT_NONE
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.SAVEGAMES_PATH,
 		"user://saves/",
@@ -170,7 +170,7 @@ func set_escoria_main_settings():
 			"hint": PROPERTY_HINT_DIR
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.SETTINGS_PATH,
 		"user://",
@@ -179,7 +179,7 @@ func set_escoria_main_settings():
 			"hint": PROPERTY_HINT_DIR
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.GAME_MIGRATION_PATH,
 		"",
@@ -199,7 +199,7 @@ func set_escoria_debug_settings():
 			"type": TYPE_BOOL
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.TERMINATE_ON_ERRORS,
 		true,
@@ -207,7 +207,7 @@ func set_escoria_debug_settings():
 			"type": TYPE_BOOL
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.DEVELOPMENT_LANG,
 		"en",
@@ -215,7 +215,7 @@ func set_escoria_debug_settings():
 			"type": TYPE_STRING
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.LOG_LEVEL,
 		"ERROR",
@@ -225,7 +225,7 @@ func set_escoria_debug_settings():
 			"hint_string": "ERROR,WARNING,INFO,DEBUG"
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.LOG_FILE_PATH,
 		"user://",
@@ -234,7 +234,7 @@ func set_escoria_debug_settings():
 			"hint": PROPERTY_HINT_DIR
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.LOG_FILE_PATH,
 		"We're sorry, but the game crashed. Please send us the " +
@@ -244,7 +244,7 @@ func set_escoria_debug_settings():
 			"hint": PROPERTY_HINT_MULTILINE_TEXT
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.ENABLE_ROOM_SELECTOR,
 		false,
@@ -252,7 +252,7 @@ func set_escoria_debug_settings():
 			"type": TYPE_BOOL
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.ROOM_SELECTOR_ROOM_DIR,
 		"",
@@ -266,7 +266,7 @@ func set_escoria_debug_settings():
 # Prepare the settings in the Escoria sound settings
 func set_escoria_sound_settings():
 	escoria.project_settings_manager.register_setting(
-		escoria.project_settings_manager.MASTER_VOLUME, 
+		escoria.project_settings_manager.MASTER_VOLUME,
 		1,
 		{
 			"type": TYPE_REAL,
@@ -274,9 +274,9 @@ func set_escoria_sound_settings():
 			"hint_string": "0,1"
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
-		escoria.project_settings_manager.MUSIC_VOLUME, 
+		escoria.project_settings_manager.MUSIC_VOLUME,
 		1,
 		{
 			"type": TYPE_REAL,
@@ -284,9 +284,9 @@ func set_escoria_sound_settings():
 			"hint_string": "0,1"
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
-		escoria.project_settings_manager.SFX_VOLUME, 
+		escoria.project_settings_manager.SFX_VOLUME,
 		1,
 		{
 			"type": TYPE_REAL,
@@ -294,9 +294,9 @@ func set_escoria_sound_settings():
 			"hint_string": "0,1"
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
-		escoria.project_settings_manager.SPEECH_VOLUME, 
+		escoria.project_settings_manager.SPEECH_VOLUME,
 		1,
 		{
 			"type": TYPE_REAL,
@@ -304,9 +304,9 @@ func set_escoria_sound_settings():
 			"hint_string": "0,1"
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
-		escoria.project_settings_manager.SPEECH_ENABLED, 
+		escoria.project_settings_manager.SPEECH_ENABLED,
 		1,
 		{
 			"type": TYPE_BOOL
@@ -314,17 +314,17 @@ func set_escoria_sound_settings():
 	)
 
 	escoria.project_settings_manager.register_setting(
-		escoria.project_settings_manager.SPEECH_FOLDER, 
+		escoria.project_settings_manager.SPEECH_FOLDER,
 		"res://speech",
 		{
 			"type": TYPE_STRING,
 			"hint": PROPERTY_HINT_DIR
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
-		escoria.project_settings_manager.SPEECH_EXTENSION, 
-		"ogg", 
+		escoria.project_settings_manager.SPEECH_EXTENSION,
+		"ogg",
 		{
 			"type": TYPE_STRING
 		}
@@ -345,7 +345,7 @@ func set_escoria_platform_settings():
 			"type": TYPE_BOOL
 		}
 	)
-	
+
 	escoria.project_settings_manager.register_setting(
 		escoria.project_settings_manager.SKIP_CACHE_MOBILE,
 		true,
@@ -358,7 +358,7 @@ func set_escoria_platform_settings():
 # Uninstall plugin
 func _exit_tree():
 	remove_autoload_singleton("escoria")
-	
+
 	InputMap.erase_action(escoria.inputs_manager.SWITCH_ACTION_VERB)
 	InputMap.erase_action(escoria.inputs_manager.ESC_SHOW_DEBUG_PROMPT)
 

--- a/addons/escoria-core/testing/player_angles_finder.gd
+++ b/addons/escoria-core/testing/player_angles_finder.gd
@@ -1,10 +1,10 @@
 extends Node2D
 
-# This scenes purpose is to help determining the angles between X and Y axis 
+# This scenes purpose is to help determining the angles between X and Y axis
 # when clicking somewhere on the screen.
-# Let us consider that player position is always 0,0. 
+# Let us consider that player position is always 0,0.
 # Clicking right above his head is angle 0.
-# Clicking on the right is angle 90. 
+# Clicking on the right is angle 90.
 # Clicking under his feet is angle 180.
 # etc.
 
@@ -28,7 +28,7 @@ enum Directions {
 const starting_angles = [
 	0,			# 0 NORTH
 	PI/4,		# 1 NORTHEAST
-	PI/2,		# 2 EAST 
+	PI/2,		# 2 EAST
 	3*PI/4,		# 3 SOUTHEAST
 	PI,			# 4 SOUTH
 	5*PI/4,		# 5 SOUTHWEST
@@ -39,7 +39,7 @@ const starting_angles = [
 var colors = [
 	ColorN("red"),		# 0 NORTH
 	ColorN("green"),	# 1 NORTHEAST
-	ColorN("blue"),		# 2 EAST 
+	ColorN("blue"),		# 2 EAST
 	ColorN("black"),	# 3 SOUTHEAST
 	ColorN("yellow"),	# 4 SOUTH
 	ColorN("cyan"),		# 5 SOUTHWEST
@@ -109,8 +109,8 @@ func _ready():
 	$player_animations.add_item("")
 	for anim_name in $player.get_animation_player().get_animations():
 		$player_animations.add_item(anim_name)
-	
-	# Set initial angles 
+
+	# Set initial angles
 	var initial_angle: float = 360.0 / 8.0
 	$VBoxContainer/angle_x/angle_horiz.text = str(40)
 	$VBoxContainer/angle_y/angle_vert.text = str(40)
@@ -118,7 +118,7 @@ func _ready():
 	angle_horizontal_axes = 40
 	angle_vertical_axes = 40
 	angle_diagonal_axes = 50
-	
+
 	calculate_areas()
 
 
@@ -148,17 +148,17 @@ func calculate_areas(nb_directions: int = 8):
 				angle_area = deg2rad(angle_vertical_axes)
 			Directions.NORTHEAST,Directions.NORTHWEST,Directions.SOUTHEAST,Directions.SOUTHWEST:
 				angle_area = deg2rad(angle_diagonal_axes)
-		
+
 		# Since angles start from EAST, offset by -PI/2 (= -90°) to start on up direction
 		# Then minus angle_area/2 to align on direction
 		start_angle = PI/2 + angle_area / 2
-		
+
 		var angle_start = starting_angles[i] - start_angle
 		var angle_end = angle_start + angle_area
 		angles.push_back([angle_start, angle_end])
-		
+
 		result_angles.push_back([clamp360(rad2deg(angle_start) + rad2deg(PI/2)),clamp360(rad2deg(angle_area))])
-	
+
 	$VBoxContainer/VBoxContainer/angles/angle_array.text = str(result_angles)
 	construct_scene_nodes(angles)
 
@@ -184,7 +184,7 @@ func construct_scene_nodes(angles):
 			collision_shape.points = p_points
 			collision.set_shape(collision_shape)
 			area_node.add_child(collision)
-			
+
 			$areas.add_child(polygon_node)
 
 
@@ -195,7 +195,7 @@ func _on_angle_horiz_text_changed(new_text: String):
 #	result_angles_anim.Directions.EAST.angle_area_deg = clamp360(angle_horizontal_axes)
 #	result_angles_anim.Directions.WEST.angle_area_deg = clamp360(angle_horizontal_axes)
 	calculate_areas()
-	
+
 
 func _on_angle_vert_text_changed(new_text: String):
 	if !new_text.is_valid_float():
@@ -220,7 +220,7 @@ func _on_angle_diag_text_changed(new_text: String):
 func _on_area_click(viewport: Object, event: InputEvent, shape_idx: int, area_name: String):
 	if event is InputEventMouseButton and event.is_pressed():
 		pass
-	
+
 func clamp360(angle: float):
 	if angle < 0.0:
 		while angle < 0.0:

--- a/addons/escoria-core/testing/rtl_screen_offset_testing.gd
+++ b/addons/escoria-core/testing/rtl_screen_offset_testing.gd
@@ -16,7 +16,7 @@ const MAX_HEIGHT = 500
 func _ready():
 	assert(!path_to_richtextlabel.is_empty())
 	$VBoxContainer/HBoxContainer/clamp_distance.text = str(global_distance_to_clamp)
-	
+
 	# Add a white TextureRect behind the RTL to see its actual size
 	var texturerect_node = TextureRect.new()
 	get_node(path_to_richtextlabel).add_child(texturerect_node)
@@ -29,7 +29,7 @@ func _ready():
 	texturerect_node.anchor_right = 1.0
 	texturerect_node.anchor_bottom = 1.0
 	move_child(get_node(path_to_richtextlabel), 1)
-	
+
 	update_line2d()
 	_on_new_text_pressed()
 	set_process_input(true)
@@ -56,7 +56,7 @@ func update_line2d():
 	$Line2D.add_point(Vector2(screen_width - global_distance_to_clamp, screen_height - global_distance_to_clamp))
 	$Line2D.add_point(Vector2(screen_width - global_distance_to_clamp, global_distance_to_clamp))
 	$Line2D.add_point(Vector2(global_distance_to_clamp, global_distance_to_clamp))
-	
+
 
 func _on_new_text_pressed():
 	var pressed_button = $HBoxContainer2/foo.group.get_pressed_button()
@@ -79,18 +79,18 @@ func tooltip_distance_to_edge_right(position: Vector2):
 func _on_Control_mouse_moved(mouse_pos):
 #	printt("mousepos", mouse_pos)
 #	printt("label_container_pos", rect_position)
-	
+
 	#var corrected_position = _offset(new_pos)
 	var corrected_position = mouse_pos
-	
+
 	# clamp TOP
 	if tooltip_distance_to_edge_top(mouse_pos) <= global_distance_to_clamp:
 		corrected_position.y = global_distance_to_clamp
-	
+
 	# clamp BOTTOM
 	if tooltip_distance_to_edge_bottom(mouse_pos + get_node(path_to_richtextlabel).rect_size) <= global_distance_to_clamp:
 		corrected_position.y = screen_height - global_distance_to_clamp - get_node(path_to_richtextlabel).rect_size.y
-	
+
 	# clamp LEFT
 	if tooltip_distance_to_edge_left(mouse_pos - get_node(path_to_richtextlabel).rect_size/2) <= global_distance_to_clamp:
 		corrected_position.x = global_distance_to_clamp
@@ -98,7 +98,7 @@ func _on_Control_mouse_moved(mouse_pos):
 	# clamp RIGHT
 	if tooltip_distance_to_edge_right(mouse_pos + get_node(path_to_richtextlabel).rect_size/2) <= global_distance_to_clamp:
 		corrected_position.x = screen_width - global_distance_to_clamp - get_node(path_to_richtextlabel).rect_size.x
-	
+
 	get_node(path_to_richtextlabel).anchor_right = 0.2
 	get_node(path_to_richtextlabel).rect_position = corrected_position
 
@@ -115,7 +115,7 @@ func _on_clamp_distance_text_changed(new_text):
 func _offset(position):
 	var center_offset_x = rect_size.x / 2
 	var offset_y = 5
-	
+
 	position.x -= center_offset_x
 	position.y += offset_y
 	return position
@@ -129,14 +129,14 @@ func update_size():
 	var content_height = rtl_node.get_content_height()
 	var nb_visible_characters = rtl_node.visible_characters
 	var nb_visible_lines = rtl_node.get_visible_line_count()
-	
+
 	printt("BEFORE", "text_height", content_height, "rtl_height", rtl_node.rect_size.y)
-	
+
 	# if text is too long and is wrapped
 #	var nblines = float(rtl_node.get_content_height()) / float(ONE_LINE_HEIGHT)
 	var nblines = nb_visible_lines
 	if nblines >= 1:
-		
+
 		yield(get_tree(), "idle_frame")
 		yield(get_tree(), "idle_frame")
 		var text_height = rtl_node.get_content_height()
@@ -144,20 +144,20 @@ func update_size():
 			text_height = MAX_HEIGHT
 		if text_height <= MIN_HEIGHT:
 			text_height = MIN_HEIGHT
-		
+
 		var parent_width = rtl_node.rect_size.x
-		
+
 		# first, try to increase width until it goes above max_width
 		while parent_width < max_width && float(text_height) / float(ONE_LINE_HEIGHT) > 1.0:
 			rtl_node.rect_size.x += 1
 			parent_width = rtl_node.rect_size.x
-		
-		
+
+
 		rtl_node.rect_size.y = text_height
-		
+
 		if rtl_node.rect_size.x >= max_width:
 			rtl_node.rect_size.x = max_width
-		
+
 	## END RECT_SIZE ##
 	rtl_node.anchor_top = 0.0
 	rtl_node.anchor_right = 0.0

--- a/addons/escoria-core/ui_library/inventory/esc_inventory_button.gd
+++ b/addons/escoria-core/ui_library/inventory/esc_inventory_button.gd
@@ -77,22 +77,22 @@ func _on_inventory_item_gui_input(event: InputEvent):
 		if event.doubleclick:
 			if event.button_index == BUTTON_LEFT:
 				emit_signal(
-					"mouse_double_left_inventory_item", 
-					global_id, 
+					"mouse_double_left_inventory_item",
+					global_id,
 					event
 				)
 		else:
 			if event.is_pressed():
 				if event.button_index == BUTTON_LEFT:
 					emit_signal(
-						"mouse_left_inventory_item", 
-						global_id, 
+						"mouse_left_inventory_item",
+						global_id,
 						event
 					)
 				if event.button_index == BUTTON_RIGHT:
 					emit_signal(
-						"mouse_right_inventory_item", 
-						global_id, 
+						"mouse_right_inventory_item",
+						global_id,
 						event
 					)
 

--- a/addons/escoria-core/ui_library/menus/load_save/load/load_game.gd
+++ b/addons/escoria-core/ui_library/menus/load_save/load/load_game.gd
@@ -32,7 +32,7 @@ func _on_back_pressed():
 func refresh_savegames():
 	for slot in $VBoxContainer/ScrollContainer/slots.get_children():
 		$VBoxContainer/ScrollContainer/slots.remove_child(slot)
-	
+
 	var saves_list = escoria.save_manager.get_saves_list()
 	if not saves_list.empty():
 		for save_key in saves_list.keys():

--- a/addons/escoria-core/ui_library/menus/load_save/save/save_game.gd
+++ b/addons/escoria-core/ui_library/menus/load_save/save/save_game.gd
@@ -32,7 +32,7 @@ func refresh_savegames():
 	var _slots = $VBoxContainer/ScrollContainer/slots
 	for slot in _slots.get_children():
 		_slots.remove_child(slot)
-	
+
 	var saves_list = escoria.save_manager.get_saves_list()
 	if not saves_list.empty():
 		for save_key in saves_list.keys():
@@ -40,7 +40,7 @@ func refresh_savegames():
 			_slots.add_child(new_slot)
 			new_slot.set_slot_name_date(saves_list[save_key]["name"], saves_list[save_key]["date"])
 			new_slot.connect("pressed", self, "_on_slot_pressed", [save_key])
-	
+
 	var datetime = OS.get_datetime()
 	var datetime_string = "%02d/%02d/%02d %02d:%02d" % [
 		datetime["day"],

--- a/addons/escoria-core/ui_library/menus/options/options.gd
+++ b/addons/escoria-core/ui_library/menus/options/options.gd
@@ -24,9 +24,9 @@ func _ready() -> void:
 			$VBoxContainer/MarginContainer/options/flags
 	for child in _flags_container.get_children():
 		_flags_container.remove_child(child)
-		
+
 	_loaded_languages = []
-	
+
 	for lang in TranslationServer.get_loaded_locales():
 		if not lang in _loaded_languages:
 			_loaded_languages.append(lang)
@@ -88,7 +88,7 @@ func _on_music_volume_changed(value):
 	escoria.settings["music_volume"] = value
 	escoria.apply_settings(escoria.settings)
 	settings_changed = true
-	
+
 
 # General volume was changed
 #

--- a/addons/escoria-core/ui_library/tools/room_select/room_select.gd
+++ b/addons/escoria-core/ui_library/tools/room_select/room_select.gd
@@ -33,7 +33,7 @@ func _ready():
 			if dir.current_is_dir():
 				rooms_list.push_back(file_name)
 			file_name = dir.get_next()
-		
+
 		rooms_list.sort()
 		for room in rooms_list:
 			add_item(room)
@@ -44,14 +44,14 @@ func _ready():
 			])
 
 	else:
-		escoria.logger.report_warnings("room_select.gd:_ready()", 
+		escoria.logger.report_warnings("room_select.gd:_ready()",
 			["A problem occurred while opening rooms folder."])
-	
+
 
 # Switch to the selected room
 func _on_button_pressed():
 	# When next room is loaded, we don't want to consider ESC_LAST_SCENE for
-	# automatic transitions. 
+	# automatic transitions.
 	# If FORCE_LAST_SCENE_NULL is True when change_scene starts:
 	# - ESC_LAST_SCENE is set to empty
 	escoria.globals_manager.set_global(
@@ -67,7 +67,7 @@ func _on_button_pressed():
 	escoria.event_manager.interrupt_running_event()
 	escoria.event_manager.clear_event_queue()
 	escoria.event_manager.queue_event(script.events['room_selector'])
-	
+
 
 
 # A room was selected, store the selection

--- a/addons/escoria-dialog-simple/esc_dialog_simple.gd
+++ b/addons/escoria-dialog-simple/esc_dialog_simple.gd
@@ -49,9 +49,9 @@ func say(dialog_player: Node, global_id: String, text: String, type: String):
 		_type_player = preload(\
 			"res://addons/escoria-dialog-simple/types/avatar.tscn"\
 		).instance()
-		
+
 	_type_player.connect("say_finished", self, "_on_say_finished", [], CONNECT_ONESHOT)
-	
+
 	_dialog_player.add_child(_type_player)
 	_type_player.say(global_id, text)
 #	yield(_type_player, "say_finished")

--- a/addons/escoria-dialog-simple/types/floating.gd
+++ b/addons/escoria-dialog-simple/types/floating.gd
@@ -46,10 +46,10 @@ func _ready():
 	)
 	bbcode_enabled = true
 	$Tween.connect("tween_completed", self, "_on_dialog_line_typed")
-	
+
 	escoria.connect("paused", self, "_on_paused")
 	escoria.connect("resumed", self, "_on_resumed")
-	
+
 
 func _process(delta):
 	if _current_character.is_inside_tree() and \
@@ -58,13 +58,13 @@ func _process(delta):
 		rect_position = _current_character.get_node("dialog_position") \
 			.get_global_transform_with_canvas().origin
 		rect_position.x -= rect_size.x / 2
-		
+
 		if rect_position.x < 0:
 			rect_position.x = 0
-		
+
 		var screen_margin = rect_position.x + rect_size.x - \
 				ProjectSettings.get("display/window/size/width")
-					
+
 		if screen_margin > 0:
 			rect_position.x -= screen_margin
 
@@ -76,19 +76,19 @@ func _process(delta):
 # - line: Line to say
 func say(character: String, line: String) :
 	show()
-	
+
 	_is_speeding_up = false
-	
+
 	# Position the RichTextLabel on the character's dialog position, if any.
 	_current_character = escoria.object_manager.get_object(character).node
-	
+
 	# Set text color to color set in the actor
 	var text_color = _current_character.dialog_color
 	var text_color_html = text_color.to_html(false)
-	
+
 	text_node.bbcode_text = "[center][color=#" + text_color_html + "]" \
 		.format([text_color_html]) + tr(line) + "[/color][center]"
-	
+
 	if _current_character.is_inside_tree() and \
 			_current_character.has_node("dialog_position"):
 		rect_position = _current_character.get_node(
@@ -98,21 +98,21 @@ func say(character: String, line: String) :
 	else:
 		rect_position.x = 0
 		rect_size.x = ProjectSettings.get_setting("display/window/size/width")
-	
+
 	if rect_position.x < 0:
 		rect_position.x = 0
-	
+
 	var screen_margin = rect_position.x + rect_size.x - \
 			ProjectSettings.get("display/window/size/width")
-				
+
 	if screen_margin > 0:
 		rect_position.x -= screen_margin
-	
+
 	_current_character.start_talking()
-	
+
 	text_node.percent_visible = 0.0
 	var time_show_full_text = _text_speed_per_character * len(line)
-	
+
 	tween.interpolate_property(text_node, "percent_visible",
 		0.0, 1.0, time_show_full_text,
 		Tween.TRANS_LINEAR, Tween.EASE_IN_OUT)
@@ -145,7 +145,7 @@ func _on_dialog_finished():
 	if is_instance_valid(_current_character) and _current_character != null:
 		_current_character.stop_talking()
 	emit_signal("say_finished")
-	
+
 
 # Handler managing pause notification from Escoria
 func _on_paused():


### PR DESCRIPTION
As Godot 3.4.2 automatically removes whitespace from gd files when the project is run, this PR is to fix all files.
After whitespace removal and testing the demo, Godot changed 2 files again, so these were recommitted. No further changes occurred after opening every room in the demo.