### PR TITLE
chore: Create a codeowners file for default PR reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Escoria developers own the code
+* @StraToN @BHSDuncan @dploeger


### PR DESCRIPTION
This sets the codeowners of this repo, which results in us being added as default reviewers. Once this is merged, I'll set the minimum reviewer count for PRs to 2, so we have the discussed quorum.