### PR TITLE
fix: enable transition to ESCRoom even if esc_script is not set

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
@@ -267,7 +267,7 @@ func init_room(room: ESCRoom) -> void:
 #
 # - room: The ESCRoom to be initialized for use.
 func _perform_script_events(room: ESCRoom):
-	if room.esc_script and escoria.event_manager.is_channel_free(escoria.event_manager.CHANNEL_FRONT) \
+	if escoria.event_manager.is_channel_free(escoria.event_manager.CHANNEL_FRONT) \
 			or (
 				not escoria.event_manager.is_channel_free(escoria.event_manager.CHANNEL_FRONT) and \
 				not escoria.event_manager.get_running_event(


### PR DESCRIPTION
When creating a new `ESCRoom`, there was a bug where it was not possible
to transition into the room if the room's `esc_script` was not set.
Apparently, `_perform_script_events()` would bail out early when
`room.esc_script` is falsy, which seems to be why the transition does
not happen.

Perhaps this defensive check was necessary at one time, but that does
not appear to be the case today because the only code that reads
`room.esc_script` in this file is within the `_run_script_event()`
function, which does its own defensive check for `room.esc_script`. As
such, it appears that we can let the rest of `_perform_script_events()`
do its thing even when `room.esc_script` is falsy (i.e., `""`).