### PR TITLE
feat: register_custom_background_input_handler() API

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_background.gd
+++ b/addons/escoria-core/game/core-scripts/esc_background.gd
@@ -85,6 +85,8 @@ func _ready():
 func _unhandled_input(event) -> void:
 	if not escoria.current_state == escoria.GAME_STATE.DEFAULT:
 		return
+	if escoria.inputs_manager.handle_background_input(event):
+		return
 	if InputMap.has_action(escoria.inputs_manager.SWITCH_ACTION_VERB) \
 			and event.is_action_pressed(escoria.inputs_manager.SWITCH_ACTION_VERB):
 		if event.button_index == BUTTON_WHEEL_UP:

--- a/addons/escoria-core/game/inputs_manager.gd
+++ b/addons/escoria-core/game/inputs_manager.gd
@@ -31,6 +31,7 @@ var hover_stack: Array = []
 # The global id of the topmost item from the hover_stack
 var hotspot_focused: String = ""
 
+var custom_background_input_handler = null
 
 # Register core signals (from escoria.gd)
 func register_core():
@@ -99,6 +100,24 @@ func register_background(background: ESCBackground):
 		"_on_mousewheel_action",
 		[-1]
 	)
+
+
+# Registers a function that has the first chance to process
+# _unhandled_input in an ESCBackground when in GAME_STATE.DEFAULT.
+# The callback receives the InputEvent as its only argument and
+# must represent a bool indicating whether it handled the event.
+# If true, ESCBackground will not attempt to process the event.
+#
+# Note that funcref() is helpful in defining a callback function.
+func register_custom_background_input_handler(callback) -> void:
+	custom_background_input_handler = callback
+
+
+func handle_background_input(event) -> bool:
+	if custom_background_input_handler:
+		return custom_background_input_handler.call_func(event)
+	else:
+		return false
 
 
 # Clear the stack of hovered items


### PR DESCRIPTION
This introduces a new API on `ESCInputsManager` that makes it
possible to inject custom logic for processing input events.
https://github.com/bolinfest/escoria-demo-game/commit/ae786cfd17e080f99a0194a125ce055ccc433531
is an example of how this could be used to add support for keyboard
shortcuts to select a specific verb.