### PR TITLE
refactor: remove redundant check for camera node

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -489,7 +489,8 @@ func update_idle():
 # Return the camera position if a camera_position_node exists or the
 # global position of the player
 func get_camera_node():
-	if camera_node and get_node(camera_node):
+	if has_node(camera_node):
+		escoria.logger.debug("Camera node found - directing camera to the camera_node on " + global_id)
 		return get_node(camera_node)
 	return self
 


### PR DESCRIPTION
@StraToN @dploeger @dploeger FYI 
I couldn't find any reason you needed to set camera_node in ESCItem to get push commands to work. As far as I can tell it's not necessary so I've removed it. If I'm wrong and it ends up that it's needed, the camera node setting in ESCItem (what it's for and what you set it to) needs to be documented.