### PR TITLE
fix: parameter validation function cant print necessary arrays on error

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/types/esc_command_argument_descriptor.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_command_argument_descriptor.gd
@@ -59,9 +59,7 @@ func validate(command: String, arguments: Array) -> bool:
 		escoria.logger.report_errors(
 			"Invalid command arguments for command %s" % command,
 			[
-				"Arguments didn't match minimum size %d: %s" %
-					self.min_args,
-					arguments
+				"Arguments didn't match minimum size {num}: {args}".format({"num":self.min_args,"args":arguments})
 			]
 		)
 


### PR DESCRIPTION
While looking into [issue 139](https://github.com/godot-escoria/escoria-issues/issues/139) I came across a bug. The validate command can't print the error message it's supposed to. The "%s" that is supposed to print the "arguments" array fails. The error message given is "not enough arguments for format string in operator '%'.

Test this by just changing the arguments.size comparison (line 58, esc_command_argument_descriptor.gd) from
```
if arguments.size() < self.min_args:
```
to
```
if arguments.size() < 50:
```
![image](https://user-images.githubusercontent.com/5151242/155434098-aceb3525-34b3-48f5-9025-ff5eed925587.png)
