### PR TITLE
fix: camera commands to use time instead of speed

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_pos.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_pos.gd
@@ -1,10 +1,10 @@
-# `camera_set_pos speed x y`
+# `camera_set_pos time x y`
 #
 # Moves the camera to the given position.
 #
 # **Parameters**
 #
-# - *speed*: Number of seconds the transition should take
+# - *time*: Number of seconds the transition should take
 # - *x*: Target X coordinate
 # - "y*: Target Y coordinate
 #

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_target.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_target.gd
@@ -1,10 +1,10 @@
-# `camera_set_target speed object`
+# `camera_set_target time object`
 #
 # Configures the camera to follow the specified target `object`
 #
 # **Parameters**
 #
-# - *speed*: Number of seconds the transition should take
+# - *time*: Number of seconds the transition should take
 # - *object*: Global ID of the target object
 #
 # For more details see: https://docs.escoria-framework.org/camera

--- a/addons/escoria-core/game/scenes/camera_player/esc_camera.gd
+++ b/addons/escoria-core/game/scenes/camera_player/esc_camera.gd
@@ -87,21 +87,17 @@ func set_drag_margin_enabled(p_dm_h_enabled, p_dm_v_enabled):
 #
 # #### Parameters
 # - p_target: Object to target
-# - p_speed: Number of seconds for the camera to reach the target
-func set_target(p_target, p_speed : float = 0.0):
-	var speed = p_speed
-
+# - p_time: Number of seconds for the camera to reach the target
+func set_target(p_target, p_time : float = 0.0):
 	_resolve_target_and_zoom(p_target)
 
 	escoria.logger.info(
 		"Current camera position = %s " % str(self.global_position)
 	)
 
-	if speed == 0.0:
+	if p_time == 0.0:
 		self.global_position = _target
 	else:
-		var time = self.global_position.distance_to(_target) / speed
-
 		if _tween.is_active():
 			escoria.logger.report_warnings(
 				"esc_camera.gd:set_target()",
@@ -119,7 +115,7 @@ func set_target(p_target, p_speed : float = 0.0):
 			"global_position",
 			self.global_position,
 			_target,
-			time,
+			p_time,
 			Tween.TRANS_LINEAR,
 			Tween.EASE_IN_OUT
 		)


### PR DESCRIPTION
@StraToN @dploeger @BHSDuncan Fixes https://github.com/godot-escoria/escoria-issues/issues/136.
This makes all the camera commands consistent (i.e. using time instead of speed)