### PR TITLE
chore: add override.cfg to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ bin
 .import
 *.translation
 .godot
+
+# Local overrides to project.godot go in override.cfg.
+/override.cfg


### PR DESCRIPTION
For example, this makes it easier to do a bunch of testing
to `escoria-ui-simplemouse` without making a temporary change
to `project.godot` because you can create `override.cfg` with
the following:

```
[escoria]
ui/game_scene="res://addons/escoria-ui-simplemouse/game.tscn"
```