### PR TITLE
feat: add gamepad support to escoria-ui-simplemouse

### DIFF
--- a/addons/escoria-core/game/inputs_manager.gd
+++ b/addons/escoria-core/game/inputs_manager.gd
@@ -21,6 +21,10 @@ const SWITCH_ACTION_VERB = "switch_action_verb"
 # Input action for use by InputMap
 const ESC_SHOW_DEBUG_PROMPT = "esc_show_debug_prompt"
 
+# Input action for use by InputMap that represents a "primary action" from an
+# input device, such as a left-click on a mouse or the X button on an XBox
+# controller
+const ESC_UI_PRIMARY_ACTION = "esc_ui_primary_action"
 
 # The current input mode
 var input_mode = INPUT_ALL


### PR DESCRIPTION
Review stack (3/3) [Prev](https://github.com/godot-escoria/escoria-demo-game/pull/503)

* #521
* #503
* :triangular_flag_on_post: #518
  * https://github.com/godot-escoria/escoria-demo-game/pull/518/commits/fd73dfa7197282bf3b18e047989cb64996fc143c feat: add gamepad support to escoria-ui-simplemouse

---

Updates escoria-ui-simplemouse to demonstrate basic gamepad support.
Addresses https://github.com/godot-escoria/escoria-issues/issues/101.