### PR TITLE
refactor: remove trailing whitespace from all .gd files

### DIFF
--- a/addons/escoria-ui-9verbs/game.gd
+++ b/addons/escoria-ui-9verbs/game.gd
@@ -119,11 +119,11 @@ func element_focused(element_id: String) -> void:
 		ESCActionManager.ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM, \
 		ESCActionManager.ACTION_INPUT_STATE.AWAITING_ITEM:
 			tooltip.set_target(target_obj.tooltip_name)
-	
+
 			# Hovering an ESCItem highlights its default action
 			if escoria.action_manager.current_action != VERB_USE and target_obj is ESCItem:
 				verbs_menu.set_by_name(target_obj.default_action)
-	
+
 		ESCActionManager.ACTION_INPUT_STATE.AWAITING_TARGET_ITEM:
 			tooltip.set_target2(target_obj.tooltip_name)
 
@@ -254,11 +254,11 @@ func inventory_item_focused(inventory_item_global_id: String) -> void:
 		ESCActionManager.ACTION_INPUT_STATE.AWAITING_VERB_OR_ITEM, \
 		ESCActionManager.ACTION_INPUT_STATE.AWAITING_ITEM:
 			tooltip.set_target(target_obj.tooltip_name)
-	
+
 			# Hovering an ESCItem highlights its default action
 			if escoria.action_manager.current_action != VERB_USE and target_obj is ESCItem:
 				verbs_menu.set_by_name(target_obj.default_action)
-	
+
 		ESCActionManager.ACTION_INPUT_STATE.AWAITING_TARGET_ITEM:
 			tooltip.set_target2(target_obj.tooltip_name)
 
@@ -275,7 +275,6 @@ func inventory_item_unfocused() -> void:
 		ESCActionManager.ACTION_INPUT_STATE.AWAITING_ITEM:
 			tooltip.set_target("")
 			verbs_menu.unselect_actions()
-	
 		ESCActionManager.ACTION_INPUT_STATE.AWAITING_TARGET_ITEM:
 			tooltip.set_target2("")
 

--- a/addons/escoria-ui-9verbs/verbs_menu.gd
+++ b/addons/escoria-ui-9verbs/verbs_menu.gd
@@ -30,5 +30,3 @@ func set_by_name(action_name: String):
 	selected_action = action_name
 	for but in get_children():
 		but.set_pressed(but.get_name() == action_name)
-	
-

--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -140,7 +140,6 @@ func left_click_on_inventory_item(inventory_item_global_id: String, event: Input
 			$mouse_layer/verbs_menu.set_tool_texture(
 				item.inventory_item.texture_normal
 			)
-	
 
 func right_click_on_inventory_item(inventory_item_global_id: String, event: InputEvent) -> void:
 	mousewheel_action(1)


### PR DESCRIPTION
Review stack (1/3) [Next](https://github.com/godot-escoria/escoria-demo-game/pull/503)

* :triangular_flag_on_post: #521
  * https://github.com/godot-escoria/escoria-demo-game/pull/521/commits/df8299fc7f1940dce3a68985c0928d1ec13de644 refactor: remove trailing whitespace from all .gd files
* #503
* #518 