### PR TITLE
Fix wrong (old) documentation about setup and ready events

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/types/esc_event.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_event.gd
@@ -2,8 +2,12 @@
 #
 # Events are triggered from various sources. Common events include
 #
-# * :setup Called every time when visiting a scene
-# * :ready Called the first time a scene is visited
+# * :setup : This is the first event to be called every time a room is visited. 
+#    It allows elements in the room to be prepared *before* the room is displayed to the 
+#    player (e.g. starting particle effects)
+# * :ready : This is the second event to be called every time a room is visited.
+#    This event is run right *after* the room is displayed to the player,
+#    allowing cutscenes or animations to be run at this moment.
 # * :use <global id> Called from the current item when it is used with the item
 #   with the global id <global id>
 extends ESCStatement


### PR DESCRIPTION
As a matter of fact, both `setup` and `ready` events are run every time a room is visited, one after the other.
`setup` is run first, before the room is visible on screen (to prepare elements and items) so that the player doesn't see elements teleporting around.
`ready` is run second, when the room is visible on screen. That's where some cutscenes can be run, for example.