### PR TITLE
fix: Automatically remove trailing whitespace when parsing scripts

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_compiler.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_compiler.gd
@@ -117,7 +117,7 @@ func _compile(lines: Array) -> Array:
 	var returned = []
 
 	while lines.size() > 0:
-		var line = lines.pop_front()
+		var line = lines.pop_front().strip_edges(false, true)
 		escoria.logger.trace("Parsing line %s" % line)
 		if _comment_regex.search(line) or _empty_regex.search(line):
 			# Ignore comments and empty lines


### PR DESCRIPTION
fix: Automatically remove trailing whitespace when parsing scripts to avoid needing to change all regular expressions separately
fixes https://github.com/godot-escoria/escoria-issues/issues/172