### PR TITLE
fix: Updated camera x limit to 1280 to match the background graphics in each room

### DIFF
--- a/game/rooms/room01/room01.tscn
+++ b/game/rooms/room01/room01.tscn
@@ -24,7 +24,7 @@ __meta__ = {
 global_id = "room1"
 esc_script = "res://game/rooms/room01/esc/room01.esc"
 player_scene = ExtResource( 4 )
-camera_limits = [ Rect2( 0, 0, 1285, 550 ) ]
+camera_limits = [ Rect2( 0, 0, 1280, 550 ) ]
 editor_debug_mode = 1
 
 [node name="ESCBackground" type="TextureRect" parent="."]

--- a/game/rooms/room02/room02.tscn
+++ b/game/rooms/room02/room02.tscn
@@ -192,7 +192,7 @@ script = ExtResource( 6 )
 global_id = "room2"
 esc_script = "res://game/rooms/room02/esc/room02_bridge.esc"
 player_scene = ExtResource( 4 )
-camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
+camera_limits = [ Rect2( 0, 0, 1280, 555 ) ]
 editor_debug_mode = 1
 
 [node name="r_platform" type="Area2D" parent="."]
@@ -315,6 +315,7 @@ script = ExtResource( 10 )
 debug_mode = 1
 
 [node name="bridge_open" type="NavigationPolygonInstance" parent="walkable_area"]
+visible = false
 navpoly = SubResource( 4 )
 
 [node name="bridge_closed" type="NavigationPolygonInstance" parent="walkable_area"]

--- a/game/rooms/room03/room03.tscn
+++ b/game/rooms/room03/room03.tscn
@@ -147,7 +147,7 @@ script = ExtResource( 6 )
 global_id = "room3"
 esc_script = "res://game/rooms/room03/esc/room03_bridge.esc"
 player_scene = ExtResource( 4 )
-camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
+camera_limits = [ Rect2( 0, 0, 1280, 555 ) ]
 
 [node name="Hotspots" type="Node2D" parent="."]
 

--- a/game/rooms/room08/room08.tscn
+++ b/game/rooms/room08/room08.tscn
@@ -210,7 +210,7 @@ __meta__ = {
 global_id = "room8"
 esc_script = "res://game/rooms/room08/esc/room08.esc"
 player_scene = ExtResource( 4 )
-camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
+camera_limits = [ Rect2( 0, 0, 1280, 555 ) ]
 
 [node name="walkable_area" type="Navigation2D" parent="."]
 script = ExtResource( 1 )

--- a/game/rooms/room09/room09.tscn
+++ b/game/rooms/room09/room09.tscn
@@ -412,7 +412,7 @@ __meta__ = {
 global_id = "room9"
 esc_script = "res://game/rooms/room09/esc/room09.esc"
 player_scene = ExtResource( 4 )
-camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
+camera_limits = [ Rect2( 0, 0, 1280, 555 ) ]
 
 [node name="walkable_area" type="Navigation2D" parent="."]
 script = ExtResource( 1 )

--- a/game/rooms/room10/room10.tscn
+++ b/game/rooms/room10/room10.tscn
@@ -23,7 +23,7 @@ __meta__ = {
 global_id = "room10"
 esc_script = "res://game/rooms/room10/esc/room10.esc"
 player_scene = ExtResource( 4 )
-camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
+camera_limits = [ Rect2( 0, 0, 1280, 555 ) ]
 
 [node name="walkable_area" type="Navigation2D" parent="."]
 script = ExtResource( 1 )

--- a/game/rooms/room11/room11.tscn
+++ b/game/rooms/room11/room11.tscn
@@ -25,7 +25,7 @@ __meta__ = {
 global_id = "room11"
 esc_script = "res://game/rooms/room11/esc/room11.esc"
 player_scene = ExtResource( 4 )
-camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
+camera_limits = [ Rect2( 0, 0, 1280, 555 ) ]
 
 [node name="background" parent="." instance=ExtResource( 2 )]
 

--- a/game/rooms/room12/room12.tscn
+++ b/game/rooms/room12/room12.tscn
@@ -26,7 +26,7 @@ __meta__ = {
 global_id = "room12"
 esc_script = "res://game/rooms/room12/esc/room12.esc"
 player_scene = ExtResource( 4 )
-camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
+camera_limits = [ Rect2( 0, 0, 1280, 555 ) ]
 
 [node name="walkable_area" type="Navigation2D" parent="."]
 script = ExtResource( 1 )

--- a/game/rooms/room13/room13.tscn
+++ b/game/rooms/room13/room13.tscn
@@ -24,7 +24,7 @@ __meta__ = {
 }
 global_id = "room13"
 esc_script = "res://game/rooms/room13/esc/room13.esc"
-camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
+camera_limits = [ Rect2( 0, 0, 1280, 555 ) ]
 
 [node name="background" parent="." instance=ExtResource( 2 )]
 

--- a/game/rooms/room14/room14.tscn
+++ b/game/rooms/room14/room14.tscn
@@ -24,7 +24,7 @@ __meta__ = {
 global_id = "room14"
 esc_script = "res://game/rooms/room14/esc/room14.esc"
 player_scene = ExtResource( 4 )
-camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
+camera_limits = [ Rect2( 0, 0, 1280, 555 ) ]
 
 [node name="background" parent="." instance=ExtResource( 2 )]
 

--- a/game/rooms/room15/room15.tscn
+++ b/game/rooms/room15/room15.tscn
@@ -21,7 +21,7 @@ __meta__ = {
 }
 global_id = "room15"
 player_scene = ExtResource( 4 )
-camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
+camera_limits = [ Rect2( 0, 0, 1280, 555 ) ]
 
 [node name="background" parent="." instance=ExtResource( 2 )]
 

--- a/game/rooms/room16/room16.tscn
+++ b/game/rooms/room16/room16.tscn
@@ -23,7 +23,7 @@ __meta__ = {
 global_id = "room16"
 esc_script = "res://game/rooms/room16/esc/room16.esc"
 player_scene = ExtResource( 4 )
-camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
+camera_limits = [ Rect2( 0, 0, 1280, 555 ) ]
 
 [node name="background" parent="." instance=ExtResource( 2 )]
 

--- a/game/rooms/room17/room17.tscn
+++ b/game/rooms/room17/room17.tscn
@@ -21,7 +21,7 @@ __meta__ = {
 }
 global_id = "room17"
 player_scene = ExtResource( 4 )
-camera_limits = [ Rect2( 0, 0, 1289, 555 ) ]
+camera_limits = [ Rect2( 0, 0, 1280, 555 ) ]
 
 [node name="background" parent="." instance=ExtResource( 2 )]
 


### PR DESCRIPTION
fix: Updated camera x limit to 1280 to match the background graphics in each room
I've left room5 and 6 out as they have separate PRs.