### PR TITLE
fix: player_start needed to be where the level description is

### DIFF
--- a/game/rooms/room07/room07.tscn
+++ b/game/rooms/room07/room07.tscn
@@ -1083,12 +1083,9 @@ margin_bottom = 585.0
 custom_fonts/font = ExtResource( 5 )
 text = "This trigger activates when
  player walks out only"
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="player_start" type="Position2D" parent="."]
-position = Vector2( 1655, 1132 )
+position = Vector2( 128, 1162 )
 script = ExtResource( 8 )
 global_id = "r7_player_start"
 is_start_location = true


### PR DESCRIPTION
I'd put the player start in the right hand side of the room while testing and didn't move it back. Now it's back where the user can immediately read the level description.