### PR TITLE
fix: Reset audio bus layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ bin
 
 # Local overrides to project.godot go in override.cfg.
 /override.cfg
+
+# Disable accidental changes to the default bus layout. If a change to this
+# file is required, use git add --force 
+addons/escoria-core/default_bus_layout.tres

--- a/addons/escoria-core/default_bus_layout.tres
+++ b/addons/escoria-core/default_bus_layout.tres
@@ -1,7 +1,6 @@
 [gd_resource type="AudioBusLayout" format=2]
 
 [resource]
-bus/0/volume_db = -8.89811
 bus/1/name = "SFX"
 bus/1/solo = false
 bus/1/mute = false
@@ -12,7 +11,7 @@ bus/2/name = "Music"
 bus/2/solo = false
 bus/2/mute = false
 bus/2/bypass_fx = false
-bus/2/volume_db = -60.0
+bus/2/volume_db = 0.0
 bus/2/send = "Master"
 bus/3/name = "Speech"
 bus/3/solo = false


### PR DESCRIPTION
Apparently Godot stores the settings of the audio bus layout in the editor locally somewhere. We set "default audio bus layout" to the resource file in this commit and when starting up the auditor, Godot loads the bus layout setting and applies it to the resource file.

This is just to reset the layout to 0db for each channel. If any dev should've changed the layout in their editor, they should reset their layout as well.