### PR TITLE
fix: eliminate escoria/esc/command_paths that duplicates escoria/main…

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_compiler.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_compiler.gd
@@ -13,6 +13,9 @@ const EMPTY_REGEX = '^\\s*$'
 const INDENT_REGEX_GROUP = "indent"
 const INDENT_REGEX = '^(?<%s>\\s*)' % INDENT_REGEX_GROUP
 
+# This must match ESCProjectSettingsManager.COMMAND_DIRECTORIES.
+# We do not reference it directly to avoid circular dependencies.
+const COMMAND_DIRECTORIES = "escoria/main/command_directories"
 
 # RegEx objects for use by the ESC compiler
 var _comment_regex
@@ -49,12 +52,12 @@ func _init():
 	# Assure command list preference
 	# (we use ProjectSettings instead of escoria.project_settings_manager
 	# here because this is called from escoria._init())
-	if not ProjectSettings.has_setting("escoria/esc/command_paths"):
-		ProjectSettings.set_setting("escoria/esc/command_paths", [
+	if not ProjectSettings.has_setting(COMMAND_DIRECTORIES):
+		ProjectSettings.set_setting(COMMAND_DIRECTORIES, [
 			"res://addons/escoria-core/game/core-scripts/esc/commands"
 		])
 		var property_info = {
-			"name": "escoria/esc/command_paths",
+			"name": COMMAND_DIRECTORIES,
 			"type": TYPE_STRING_ARRAY
 		}
 		ProjectSettings.add_property_info(property_info)

--- a/addons/escoria-core/game/project_settings_manager.gd
+++ b/addons/escoria-core/game/project_settings_manager.gd
@@ -21,7 +21,6 @@ const TRANSITION_PATHS = "%s/%s/transition_paths" % [_ESCORIA_SETTINGS_ROOT, _UI
 const _MAIN_ROOT = "main"
 
 const COMMAND_DIRECTORIES = "%s/%s/command_directories" % [_ESCORIA_SETTINGS_ROOT, _MAIN_ROOT]
-const COMMAND_PATHS = "%s/%s/command_paths" % [_ESCORIA_SETTINGS_ROOT, _MAIN_ROOT]
 const FORCE_QUIT = "%s/%s/force_quit" % [_ESCORIA_SETTINGS_ROOT, _MAIN_ROOT]
 const GAME_MIGRATION_PATH = "%s/%s/game_migration_path" % [_ESCORIA_SETTINGS_ROOT, _MAIN_ROOT]
 const GAME_VERSION = "%s/%s/game_version" % [_ESCORIA_SETTINGS_ROOT, _MAIN_ROOT]

--- a/project.godot
+++ b/project.godot
@@ -761,7 +761,6 @@ debug/crash_message="We're sorry, but the game crashed. Please send us the follo
 
 %s"
 ui/default_dialog_scene="res://addons/escoria-core/ui_library/dialogs/floating_dialog_player.tscn"
-esc/command_paths=[ "res://addons/escoria-core/game/core-scripts/esc/commands" ]
 main/game_migration_path=""
 
 [input]


### PR DESCRIPTION
…/command_directories

It appears that the settings `escoria/esc/command_paths` and
`escoria/main/command_directories` have duplicate purposes.
Unfortunately, they are read in different places, so if you add a
directory to one setting, it will not be present in the other.
Specifically, `ESCCompiler` read from `escoria/esc/command_paths`
while `ESCCommand` and `ESCCommandRegistry` read from
`escoria/main/command_directories`.

As the `COMMAND_PATHS` constant had no references, it seemed more
appropriate to delete.

The `escoria/esc/command_paths` appears to have been set initially in
`project.godot` as part of:

https://github.com/godot-escoria/escoria-demo-game/pull/467