### PR TITLE
RFC: use room.name/node.name as global_id if not set

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -164,6 +164,16 @@ var _movable: ESCMovable = null
 var _animation_player: ESCAnimationPlayer = null
 
 
+# Returns null if no ESCRoom can be found.
+static func find_room_for_item(item: Node) -> ESCRoom:
+	var node = item
+	while node:
+		node = node.get_parent()
+		if node is ESCRoom:
+			return node
+	return null
+
+
 # Add the movable node, connect signals, detect child nodes
 # and register this item
 func _ready():
@@ -194,6 +204,12 @@ func _ready():
 				self,
 				"_update_terrain"
 			)
+
+		if global_id.empty() and not name.empty():
+			var room = find_room_for_item(self)
+			if room and not room.global_id.empty():
+				global_id = room.global_id + "/" + name
+				escoria.logger.info("derived global_id: %s" % global_id)
 
 		escoria.object_manager.register_object(
 			ESCObject.new(
@@ -501,7 +517,7 @@ func start_talking():
 			and _movable.last_dir >= 0 \
 			and _movable.last_dir < animations.speaks.size():
 		var animation_player = get_animation_player()
-	
+
 		if animation_player.is_playing():
 			animation_player.stop()
 
@@ -522,7 +538,7 @@ func stop_talking():
 			and _movable.last_dir >= 0 \
 			and _movable.last_dir < animations.speaks.size():
 		var animation_player = get_animation_player()
-	
+
 		if animation_player.is_playing():
 			animation_player.stop()
 

--- a/game/rooms/room02/esc/room02_bridge.esc
+++ b/game/rooms/room02/esc/room02_bridge.esc
@@ -10,18 +10,26 @@
 	set_interactive r2_right_platform false
 
 > [eq ESC_LAST_SCENE room1]
-	teleport player r2_l_exit
+  # Ideally, we would also make changes to ESC commands that could
+  # also support the "local" name, so this could just be:
+  #
+  #     teleport player l_door
+  #
+  # Perhaps ESCObjectManager.get_object(id) would first check for `id`
+  # and if not found `room/id`.
+	teleport player room2/l_door
+
 	# Set player look left
 	set_angle player 180
 	stop
-	
+
 > [eq ESC_LAST_SCENE room3]
 	teleport player r2_r_exit
 	# Set player look left
 	set_angle player 270
-	
+
 	# Activate bridge, else player is stuck
-	#set_state r2_bridge bridge_close 
+	#set_state r2_bridge bridge_close
 	#enable_terrain bridge_closed
 	#set_global r2_bridge_closed true
 	set_interactive r2_right_platform false
@@ -33,9 +41,8 @@
 :ready
 
 # DEBUG
-#set_state r2_bridge bridge_close 
+#set_state r2_bridge bridge_close
 #enable_terrain bridge_closed
 #set_global bridge_closed true
 #set_interactive r2_right_platform false
 ## /DEBUG
-

--- a/game/rooms/room02/room02.tscn
+++ b/game/rooms/room02/room02.tscn
@@ -234,7 +234,6 @@ script = ExtResource( 8 )
 [node name="l_door" type="Area2D" parent="."]
 pause_mode = 1
 script = ExtResource( 7 )
-global_id = "r2_l_exit"
 esc_script = "res://game/rooms/room02/esc/left_exit.esc"
 is_exit = true
 tooltip_name = "Left exit"


### PR DESCRIPTION
**This is for discussion, not submission**

Coming up with a globally unique id for every `ESCItem` can be challenging.
In practice, many non-inventory items are restricted to a single room.
This commit explores the idea of deriving the `ESCItem.global_id` from
the `global_id` of the containing `ESCRoom` and the name of the Godot
node for the `ESCItem` (which is often unique within the `ESCRoom` as a
matter of good practice, anyway).

The ultimate goal (not demonstrated in this RFC) would be to support
using the "short name" in ESC scripts, for convenience.