### PR TITLE
RFC: Character animation creator helper POC

### DIFF
--- a/addons/escoria-core/plugin.gd
+++ b/addons/escoria-core/plugin.gd
@@ -2,6 +2,7 @@
 tool
 extends EditorPlugin
 
+var player_button
 
 # Setup Escoria
 func _enter_tree():
@@ -24,6 +25,9 @@ func _enter_tree():
 		"audio/default_bus_layout",
 		"res://addons/escoria-core/default_bus_layout.tres"
 	)
+
+	player_button = preload("res://addons/escoria-core/ui_library/tools/character_helper.tscn").instance()
+	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, player_button)
 
 
 func _ready():
@@ -361,4 +365,5 @@ func _exit_tree():
 
 	InputMap.erase_action(escoria.inputs_manager.SWITCH_ACTION_VERB)
 	InputMap.erase_action(escoria.inputs_manager.ESC_SHOW_DEBUG_PROMPT)
-
+	remove_control_from_docks(player_button)
+	player_button.free()

--- a/addons/escoria-core/ui_library/tools/character_helper.gd
+++ b/addons/escoria-core/ui_library/tools/character_helper.gd
@@ -1,0 +1,83 @@
+tool
+extends Button
+
+# Currently erases your setup if you have the player partially / completely configured
+
+
+var PlayerDirectionCount = 4
+const DIRNAMES4 = ["_up", "_right", "_down", "_left"]
+const DIRNAMES8 = ["_up", "_up_right", "_right", "_down_right", "_down", "_down_left", "_left", "_up_left"]
+
+func _enter_tree():
+	connect("pressed", self, "clicked")
+
+
+func clicked():
+	print("Fixing player animations.")
+	var SelectedNode = EditorPlugin.new().get_editor_interface().get_selection().get_selected_nodes()
+	if SelectedNode.size() == 0:	# No node selected in the editor
+		return
+#	if not SelectedNode[0] is ESCAnimationResource: # Not an ESCItem. For some reason it's returning an Area2D resource for ESCItems
+#		return										# Possibly https://github.com/godotengine/godot-proposals/issues/18
+	if not "animations" in SelectedNode[0]:
+		print("Selected node does not appear to be an ESCItem.")
+		return
+
+	if SelectedNode[0].global_id == null or SelectedNode[0].global_id.length() == 0:
+		print("Please give the character a global_id.")
+		return
+
+	var PlayerName = SelectedNode[0].global_id
+
+	var Anim = SelectedNode[0].animations	# get_class for animations returns "Resource"
+	if Anim == null:	# They haven't set up an ESCAnimationResource
+		print("Please create an ESCAnimationResource for the \"Animations\" parameter")
+		return
+
+	Anim.dir_angles.clear()
+	Anim.directions.clear()
+	Anim.idles.clear()
+	Anim.speaks.clear()
+#
+
+	var ResS
+	var Divisor = 360 / PlayerDirectionCount
+	var LastAngle = 360 - (Divisor / 2)
+	for Loop in range(PlayerDirectionCount):
+		var Res = ESCDirectionAngle.new()
+		Res.angle_start = LastAngle % 360
+		Res.angle_size = Divisor
+		Anim.dir_angles.append(Res)
+		LastAngle += Divisor
+
+	for Loop in range(PlayerDirectionCount):
+		ResS = ESCAnimationName.new()
+		if PlayerDirectionCount == 4:
+			ResS.animation = PlayerName + DIRNAMES4[Loop]
+		elif PlayerDirectionCount == 8:
+			ResS.animation = PlayerName + DIRNAMES8[Loop]
+		else:
+			ResS.animation = PlayerName + "_dir" + str(Loop + 1)
+		Anim.directions.append(ResS)
+		print(str(ResS))#
+
+
+	for Loop in range(PlayerDirectionCount):
+		var Res = ESCAnimationName.new()
+		if PlayerDirectionCount == 4:
+			Res.animation = PlayerName + "_idle" + DIRNAMES4[Loop]
+		elif PlayerDirectionCount == 8:
+			Res.animation = PlayerName + "_idle" + DIRNAMES8[Loop]
+		else:
+			Res.animation = PlayerName + "_idle_dir" + str(Loop + 1)
+		Anim.idles.append(Res)
+
+	for Loop in range(PlayerDirectionCount):
+		var Res = ESCAnimationName.new()
+		if PlayerDirectionCount == 4:
+			Res.animation = PlayerName + "_speaks" + DIRNAMES4[Loop]
+		elif PlayerDirectionCount == 8:
+			Res.animation = PlayerName + "_speaks" + DIRNAMES8[Loop]
+		else:
+			Res.animation = PlayerName + "_speaks_dir" + str(Loop + 1)
+		Anim.speaks.append(Res)

--- a/addons/escoria-core/ui_library/tools/character_helper.tscn
+++ b/addons/escoria-core/ui_library/tools/character_helper.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/escoria-core/ui_library/tools/character_helper.gd" type="Script" id=1]
+
+[node name="Button" type="Button"]
+margin_right = 12.0
+margin_bottom = 20.0
+text = "Create Character"
+script = ExtResource( 1 )


### PR DESCRIPTION
A small POC for making life easier for developers when creating characters.
It adds a "Create Character" button to the 2D interface.
![image](https://user-images.githubusercontent.com/5151242/160760980-2f9e59c6-925f-4285-b574-b7fd0343116c.png)

When pressed, this checks that you have an ESCItem selected in the node tree and that the ESCItem has an ESCAnimationResource assigned to it. It then erases all the contents of the animation resource, and recreates the dir_angles, directions, idles and speaks resources. The number of directions is currently hard coded in the plugin but can be set to any number.

It will assume your animations have the naming convention <global_id>_walk_up / <global_id>_walk_up_right / ... / <global_id>_idle_up_right etc
If you have a number of directions other than 4 or 8, it assumes that the animations are <global_id>_walk_dir<number> / .../ <global_id>_idle_dir<number>

I'm not sure what the design should be (to replace this button) or what the ideal behavior is (it could be changed to update missing walk animation name fields for example, but it would need checkboxes or something to tell it what it should do).

Also I found there's a bug in Godot 3.4.4 that the array.append commands don't work properly - it does work on 3.3 stable though.