### PR TITLE
feat: Added ability to print globals as part of debug messages

### DIFF
--- a/addons/escoria-core/game/core-scripts/log/esc_logger.gd
+++ b/addons/escoria-core/game/core-scripts/log/esc_logger.gd
@@ -65,7 +65,7 @@ func _init():
 # #### Parameters
 #
 # * string: Text to log
-func _replace_globals(string: String):
+func _replace_globals(string: String) -> String:
 	for result in globals_regex.search_all(string):
 		var globresult = escoria.globals_manager.get_global(
 			str(result.get_string())

--- a/game/rooms/room03/esc/button.esc
+++ b/game/rooms/room03/esc/button.esc
@@ -1,6 +1,8 @@
 :look
 say player "That button must activate the bridge, but it is broken." [r3_button_broken]
 say player "It should work now." [!r3_button_broken]
+# Demonstrate printing globals as part of debug messages
+debug "r3_button_broken is currently {r3_button_broken}"
 
 :push
 say player "I must USE this."


### PR DESCRIPTION
This allows debug messages to print the contents of globals. Globals are indicated by brace symbols " { } "
```
debug "r3_button_broken is currently {r3_button_broken}"
```

I have added the function to resolve globals to all debug levels (info, warning etc) but due to [bug 219](https://github.com/godot-escoria/escoria-issues/issues/219) I can't test other debug levels so I'm not sure if the behavior is correct.

If everyone's happy with the "{ global }" notation, I'll need to update the documentation in the documentation repo. 

The alternative is Godot string notation
```
debug "Name %s is %d years old", name, age
```
But I don't know how to extend the parser to cope with this so I went with what I knew how to code :D 

Output for valid global
```
2022-4-3T11331 (D)	Running command debug with parameters [r3_button_broken is currently True] 	
2022-4-3T11331 (D)	debug command issued 	[r3_button_broken is currently {r3_button_broken}]
```

Invalid global :
```
2022-4-3T105254 (D)	Running command debug with parameters [r3_button_broken is currently Null] 	
2022-4-3T105254 (D)	debug command issued 	[r3_button_broken is currently {invalid_global}]
```

Fixes https://github.com/godot-escoria/escoria-issues/issues/205