### PR TITLE
feat: Add global interpolation for say command

### DIFF
--- a/game/rooms/room04/esc/left_exit.esc
+++ b/game/rooms/room04/esc/left_exit.esc
@@ -1,2 +1,7 @@
 :exit_scene
 change_scene "res://game/rooms/room03/room03.tscn"
+
+:look
+# Test globals in say command
+inc_global r4_door_look_count 1
+say player "You have looked at the doorway {r4_door_look_count} times"

--- a/game/rooms/room04/esc/room04.esc
+++ b/game/rooms/room04/esc/room04.esc
@@ -1,4 +1,5 @@
 :setup
+set_global r4_door_look_count 0
 
 > [eq ESC_LAST_SCENE room3]
 	teleport player l_exit

--- a/game/rooms/room04/room04.tscn
+++ b/game/rooms/room04/room04.tscn
@@ -131,7 +131,7 @@ animations = null
 polygon = PoolVector2Array( 22, 633, 21, 328, 143, 276, 143, 565 )
 
 [node name="Position2D" type="Position2D" parent="Hotspots/l_door"]
-position = Vector2( 80, 589 )
+position = Vector2( 92, 603 )
 script = ExtResource( 9 )
 
 [node name="r_door" type="Area2D" parent="Hotspots"]


### PR DESCRIPTION
Adds global interpolation for say command. Globals are indicated by putting them within braces.
This format is also suggested for debug messages as per [561](https://github.com/godot-escoria/escoria-demo-game/pull/561)

```
say player "You have looked at the doorway {r4_door_look_count} times"
```