### PR TITLE
feat: Added print command to print output at any debug level

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/print.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/print.gd
@@ -1,0 +1,26 @@
+# `print string`
+#
+# Prints a message to the log. Use this for debugging game state.
+#
+# **Parameters**
+#
+# - *string*: The string to log
+#
+# @ESC
+extends ESCBaseCommand
+class_name PrintCommand
+
+
+# Return the descriptor of the arguments of this command
+func configure() -> ESCCommandArgumentDescriptor:
+	return ESCCommandArgumentDescriptor.new(
+		1,
+		[TYPE_STRING],
+		[""]
+	)
+
+
+# Run the command
+func run(command_params: Array) -> int:
+	print(command_params[0])
+	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/log/esc_logger.gd
+++ b/addons/escoria-core/game/core-scripts/log/esc_logger.gd
@@ -54,6 +54,15 @@ func _init():
 		File.WRITE
 	)
 
+# Print a message
+#
+# #### Parameters
+#
+# * string: Text to log
+# * args: Additional information
+func print(string: String):
+	_log("(?)\t" + string)
+
 
 # Log a trace message
 #

--- a/game/rooms/room08/esc/room08.esc
+++ b/game/rooms/room08/esc/room08.esc
@@ -1,4 +1,6 @@
 :setup
+# Testing the print function
+print "This is room 8."
 
 # This code will run only the first time you enter the room.
 > [!room8_visited]


### PR DESCRIPTION
The debug command only works when the log level is set to "DEBUG". This command allows for debug message printing at any log level.
Alternatively, we could make debug print at all debug levels.