### PR TITLE
feat: Added print command to print output at any debug level

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/print.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/print.gd
@@ -1,0 +1,27 @@
+# `debug string [string2 ...]`
+#
+# Prints a message to the Godot debug window. 
+# Use this for debugging game state.
+#
+# **Parameters**
+#
+# - *string*: The string to log
+#
+# @ESC
+extends ESCBaseCommand
+class_name PrintCommand
+
+
+# Return the descriptor of the arguments of this command
+func configure() -> ESCCommandArgumentDescriptor:
+	return ESCCommandArgumentDescriptor.new(
+		1,
+		[TYPE_STRING],
+		[""]
+	)
+
+
+# Run the command
+func run(command_params: Array) -> int:
+	print(command_params[0])
+	return ESCExecution.RC_OK

--- a/game/rooms/room10/esc/room10.esc
+++ b/game/rooms/room10/esc/room10.esc
@@ -1,5 +1,6 @@
 
 :setup
+print "This is room 10"
 
 > [eq ESC_LAST_SCENE room9]
 	teleport player r10_l_exit


### PR DESCRIPTION
The current debug command is restricted to "log level = debug".  This means that you can't use it to do your own debugging if you use a different log level.
This PR adds a print command. It needs to be a separate command to debug as debug is used by the engine to print all the internal engine state. As a result, if debug was allowed to print at any log level, you would end up with engine debugging messages even at "info" level.