### PR TITLE
fix: correct change nodes of node type to node2d type to fix transitions bug

### DIFF
--- a/game/rooms/room01/room01.tscn
+++ b/game/rooms/room01/room01.tscn
@@ -83,7 +83,7 @@ script = ExtResource( 1 )
 [node name="NavigationPolygonInstance" type="NavigationPolygonInstance" parent="walkable_area"]
 navpoly = SubResource( 1 )
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="r_door" type="Area2D" parent="Hotspots"]
 pause_mode = 1

--- a/game/rooms/room04/room04.tscn
+++ b/game/rooms/room04/room04.tscn
@@ -116,7 +116,7 @@ script = ExtResource( 9 )
 global_id = "r4_player_start"
 is_start_location = true
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="l_door" type="Area2D" parent="Hotspots"]
 pause_mode = 1

--- a/game/rooms/room05/room05.tscn
+++ b/game/rooms/room05/room05.tscn
@@ -145,7 +145,7 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="l_door" type="Area2D" parent="Hotspots"]
 pause_mode = 1

--- a/game/rooms/room06/room06.tscn
+++ b/game/rooms/room06/room06.tscn
@@ -55,7 +55,7 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="l_exit" parent="Hotspots" instance=ExtResource( 3 )]
 pause_mode = 1

--- a/game/rooms/room07/room07.tscn
+++ b/game/rooms/room07/room07.tscn
@@ -807,7 +807,7 @@ position = Vector2( 0, 1403.26 )
 navpoly = SubResource( 2 )
 enabled = false
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="l_exit" type="Area2D" parent="Hotspots"]
 pause_mode = 1

--- a/game/rooms/room08/room08.tscn
+++ b/game/rooms/room08/room08.tscn
@@ -262,7 +262,7 @@ Unlocking the puzzle disables (and
 hides) the locked button, showing the
 unlocked graphic underneath."
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="l_door" type="Area2D" parent="Hotspots"]
 pause_mode = 1
@@ -411,5 +411,3 @@ position = Vector2( 139.185, 0 )
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hotspots/r8_reset_puzzle_button"]
 position = Vector2( 510.685, 190 )
 shape = SubResource( 6 )
-
-[node name="Node" type="Node" parent="Hotspots"]

--- a/game/rooms/room09/room09.tscn
+++ b/game/rooms/room09/room09.tscn
@@ -463,7 +463,7 @@ z_index = -2
 color = Color( 0, 0, 0, 1 )
 polygon = PoolVector2Array( 1172, 54, 1280, 96, 1278, 422, 1173, 355 )
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="stand" type="Area2D" parent="Hotspots"]
 pause_mode = 1

--- a/game/rooms/room10/room10.tscn
+++ b/game/rooms/room10/room10.tscn
@@ -35,7 +35,7 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="r_door" type="Area2D" parent="Hotspots"]
 script = ExtResource( 2 )
@@ -292,7 +292,7 @@ __meta__ = {
 "_edit_use_anchors_": false
 }
 
-[node name="Room_overview" type="Node" parent="."]
+[node name="Room_overview" type="Node2D" parent="."]
 
 [node name="Polygon2D" type="Polygon2D" parent="Room_overview"]
 position = Vector2( 3, -138 )

--- a/game/rooms/room11/room11.tscn
+++ b/game/rooms/room11/room11.tscn
@@ -48,7 +48,7 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="l_door" type="Area2D" parent="Hotspots"]
 pause_mode = 1

--- a/game/rooms/room12/room12.tscn
+++ b/game/rooms/room12/room12.tscn
@@ -38,7 +38,7 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="l_door" type="Area2D" parent="Hotspots"]
 pause_mode = 1

--- a/game/rooms/room13/room13.tscn
+++ b/game/rooms/room13/room13.tscn
@@ -47,7 +47,7 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="l_door" type="Area2D" parent="Hotspots"]
 pause_mode = 1

--- a/game/rooms/room14/room14.tscn
+++ b/game/rooms/room14/room14.tscn
@@ -47,7 +47,7 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="l_door" type="Area2D" parent="Hotspots"]
 pause_mode = 1

--- a/game/rooms/room15/room15.tscn
+++ b/game/rooms/room15/room15.tscn
@@ -58,7 +58,7 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="l_door" type="Area2D" parent="Hotspots"]
 pause_mode = 1

--- a/game/rooms/room16/room16.tscn
+++ b/game/rooms/room16/room16.tscn
@@ -46,7 +46,7 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="l_door" type="Area2D" parent="Hotspots"]
 pause_mode = 1

--- a/game/rooms/room17/room17.tscn
+++ b/game/rooms/room17/room17.tscn
@@ -44,7 +44,7 @@ __meta__ = {
 "_editor_description_": ""
 }
 
-[node name="Hotspots" type="Node" parent="."]
+[node name="Hotspots" type="Node2D" parent="."]
 
 [node name="l_door" type="Area2D" parent="Hotspots"]
 pause_mode = 1


### PR DESCRIPTION
When transitioning, the nodes that I'd created in the rooms of "node" type have issues with being hidden/shown at the wrong time. This fix is to change them to Node2D which supports a visibility setting.