### PR TITLE
refactor: remove deprecated debug command

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/print.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/print.gd
@@ -23,5 +23,6 @@ func configure() -> ESCCommandArgumentDescriptor:
 
 # Run the command
 func run(command_params: Array) -> int:
-	print(command_params[0])
+	# Replace the names of any globals in "{ }" with their value
+	print(escoria.logger.replace_globals(command_params[0]))
 	return ESCExecution.RC_OK

--- a/addons/escoria-core/game/core-scripts/esc/commands/say.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/say.gd
@@ -95,7 +95,8 @@ func run(command_params: Array) -> int:
 		)
 		return ESCExecution.RC_ERROR
 
-	command_params[1] = _replace_globals(command_params[1])
+	# Replace the names of any globals in "{ }" with their value
+	command_params[1] = escoria.logger.replace_globals(command_params[1])
 
 	escoria.dialog_player.say(
 		command_params[0],
@@ -105,16 +106,3 @@ func run(command_params: Array) -> int:
 	yield(escoria.dialog_player, "say_finished")
 	escoria.current_state = escoria.GAME_STATE.DEFAULT
 	return ESCExecution.RC_OK
-
-
-# Replaces terms in braces with the value of the matching global (or Null
-# if none exists)
-func _replace_globals(string: String):
-	for result in globals_regex.search_all(string):
-		var globresult = escoria.globals_manager.get_global(
-			str(result.get_string())
-		)
-		string = string.replace(
-			"{" + result.get_string() + "}", str(globresult)
-		)
-	return string

--- a/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
@@ -21,7 +21,7 @@ signal background_event_finished(return_code, event_name, channel_name)
 
 
 # Pre-defined ESC events
-const EVENT_DEBUG = "debug"
+const EVENT_PRINT = "print"
 const EVENT_EXIT_SCENE = "exit_scene"
 const EVENT_INIT = "init"
 const EVENT_LOAD = "load"

--- a/addons/escoria-core/game/core-scripts/log/esc_logger.gd
+++ b/addons/escoria-core/game/core-scripts/log/esc_logger.gd
@@ -65,7 +65,7 @@ func _init():
 # #### Parameters
 #
 # * string: Text to log
-func _replace_globals(string: String) -> String:
+func replace_globals(string: String) -> String:
 	for result in globals_regex.search_all(string):
 		var globresult = escoria.globals_manager.get_global(
 			str(result.get_string())
@@ -88,7 +88,7 @@ func _replace_globals(string: String) -> String:
 func trace(string: String, args = []):
 	if _get_log_level() >= LOG_TRACE and !crashed:
 		var argsstr = str(args) if !args.empty() else ""
-		string = _replace_globals(string)
+		string = replace_globals(string)
 		_log("(T)\t" + string + " \t" + argsstr)
 
 
@@ -104,7 +104,7 @@ func trace(string: String, args = []):
 # * args: Additional information
 func debug(string: String, args = []):
 	if _get_log_level() >= LOG_DEBUG and !crashed:
-		string = _replace_globals(string)
+		string = replace_globals(string)
 		var argsstr = str(args) if !args.empty() else ""
 		_log("(D)\t" + string + " \t" + argsstr)
 
@@ -128,7 +128,7 @@ func info(string: String, args = []):
 						argsstr.append(p.global_id)
 				else:
 					argsstr.append(str(arg))
-		string = _replace_globals(string)
+		string = replace_globals(string)
 		_log("(I)\t" + string + " \t" + str(argsstr))
 
 
@@ -145,7 +145,7 @@ func info(string: String, args = []):
 func warning(string: String, args = []):
 	if _get_log_level() >= LOG_WARNING and !crashed:
 		var argsstr = str(args) if !args.empty() else ""
-		string = _replace_globals(string)
+		string = replace_globals(string)
 		_log("(W)\t" + string + " \t" + argsstr, true)
 
 		if escoria.project_settings_manager.get_setting(
@@ -180,7 +180,7 @@ func warning(string: String, args = []):
 func error(string: String, args = [], do_savegame: bool = true):
 	if _get_log_level() >= LOG_ERROR and !crashed:
 		var argsstr = str(args) if !args.empty() else ""
-		string = _replace_globals(string)
+		string = replace_globals(string)
 		_log("(E)\t" + string + " \t" + argsstr, true)
 
 		if escoria.project_settings_manager.get_setting(

--- a/addons/escoria-core/game/scenes/esc_prompt/esc_prompt_popup.gd
+++ b/addons/escoria-core/game/scenes/esc_prompt/esc_prompt_popup.gd
@@ -9,11 +9,11 @@ onready var past_actions = $VBoxContainer/past_actions
 onready var command = $VBoxContainer/command
 
 # ESC commands kept around for references to their command names.
-var _debug: DebugCommand
+var _print: PrintCommand
 
 
 func _ready() -> void:
-	_debug = DebugCommand.new()
+	_print = PrintCommand.new()
 
 
 # Run a command
@@ -32,16 +32,16 @@ func _on_command_text_entered(p_command_str : String):
 
 	var errors = []
 	var script = escoria.esc_compiler.compile([
-		"%s%s" % [ESCEvent.PREFIX, _debug.get_command_name()],
+		"%s%s" % [ESCEvent.PREFIX, _print.get_command_name()],
 		p_command_str
 	],
 	get_class()
 	)
 
 	if script:
-		escoria.event_manager.queue_event(script.events[escoria.event_manager.EVENT_DEBUG])
+		escoria.event_manager.queue_event(script.events[escoria.event_manager.EVENT_PRINT])
 		var ret = yield(escoria.event_manager, "event_finished")
-		while ret[1] != _debug.get_command_name():
+		while ret[1] != _print.get_command_name():
 			ret = yield(escoria.event_manager, "event_finished")
 		past_actions.text += "Returned code: %d" % ret[0]
 

--- a/game/rooms/room03/esc/button.esc
+++ b/game/rooms/room03/esc/button.esc
@@ -1,8 +1,9 @@
 :look
 say player "That button must activate the bridge, but it is broken." [r3_button_broken]
 say player "It should work now." [!r3_button_broken]
-# Demonstrate printing globals as part of debug messages
-debug "r3_button_broken is currently {r3_button_broken}"
+# Demonstrate printing globals as part of print messages
+print "r3_button_broken is currently {r3_button_broken}"
+say player "r3_button_broken status : {r3_button_broken}"
 
 :push
 say player "I must USE this."


### PR DESCRIPTION
- Removed "debug" as it's been replaced by print (which works at all debug levels)
- Fixed issue where print didn't interpolate the globals in the text in all instances
- Updated the debug console to use print over debug. Compared output in the debug window when using print vs debug and the 11 debug output lines are identical (repacing everywhere that says "debug" with "print")
- Deduplicated the replace_globals function

Fixes : https://github.com/godot-escoria/escoria-issues/issues/221