### PR TITLE
feat: Added warning message when multiple locations found for an item

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -523,11 +523,7 @@ func perform_inputevent_on_object(
 					event.doubleclick
 				)
 				if context is GDScriptFunctionState:
-					context = yield(_walk_towards_object(
-						obj,
-						event.position,
-						event.doubleclick
-					), "completed")
+					context = yield(context, "completed")
 				destination_position = context.target_position
 				dont_interact = context.dont_interact_on_arrival
 
@@ -620,10 +616,14 @@ func _walk_towards_object(
 	var destination_position: Vector2
 	var dont_interact: bool = false
 
+	if obj == null || obj.node == null:
+		escoria.logger.report_errors("esc_action_manager.gd:_walk_towards_object",
+			["obj or obj.node not populated."])
+	var interact_position = obj.node.get_interact_position()
 	# If clicked object is interactive, get destination position from it.
 	if escoria.object_manager.get_object(obj.global_id).interactive:
-		if obj.node.get_interact_position() != null:
-			destination_position = obj.node.get_interact_position()
+		if interact_position != null:
+			destination_position = interact_position
 		else:
 			destination_position = obj.node.position
 	else:

--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -379,14 +379,20 @@ func get_animation_player() -> Node:
 #
 # **Returns** The interaction position
 func get_interact_position() -> Vector2:
+	var multiple_positions_found = false
 	var interact_position = null
 	for c in get_children():
 		if c is Position2D:
+			if interact_position != null:
+				multiple_positions_found = true
 			interact_position = c.global_position
 
 	if interact_position == null and collision != null:
 		interact_position = collision.global_position
 
+	if multiple_positions_found:
+		escoria.logger.warning("Multiple ESClocations found to walk to for object " +
+			"%s. Last one will be used." % global_id)
 	return interact_position
 
 


### PR DESCRIPTION
Prints a warning if there is more than one ESCLocation (position2d) as a child of an ESCITem