### PR TITLE
fix: Enforce rooms to be located at (0,0)

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
@@ -178,6 +178,17 @@ func init_room(room: ESCRoom) -> void:
 		if escoria.main.current_scene == null:
 			escoria.main.set_scene(room)
 
+	# If the room node isn't at (0,0), the walk_stop function will offset the 
+	# player by the same number of pixels when they're at the terrain edge and
+	# move them when it shouldn't.
+	if room.position != Vector2(0,0):
+		escoria.logger.report_errors(
+		"ESCRoomManager.init_room: Room node not at (0,0)",
+		[
+			"The room node's coordinates must be (0,0) instead of %s." % room.position
+		]
+	)
+
 	_perform_script_events(room)
 
 

--- a/game/rooms/room02/room02.tscn
+++ b/game/rooms/room02/room02.tscn
@@ -185,7 +185,6 @@ tracks/3/keys = {
 [sub_resource type="CapsuleShape2D" id=8]
 
 [node name="room2" type="Node2D"]
-position = Vector2( -2, 0 )
 script = ExtResource( 6 )
 global_id = "room2"
 esc_script = "res://game/rooms/room02/esc/room02_bridge.esc"


### PR DESCRIPTION
@BHSDuncan has already closed this issue as the bug was a small room misconfiguration, however on reflection, I thought it would be good to fix as it is easy to detect and flag to the developer. If we can do it in the demo levels, they can do it in the real world.
If the character is at the edge of a terrain, and you try to make them walk further, the walk_stop command will reset their location by the room offset amount (ignoring any terrains and repositioning them by an addition room's pixel offset amount each time you click).

https://github.com/godot-escoria/escoria-issues/issues/218
