### PR TITLE
fix: incorrect dialog player type

### DIFF
--- a/addons/escoria-core/game/scenes/dialogs/esc_dialog_player.gd
+++ b/addons/escoria-core/game/scenes/dialogs/esc_dialog_player.gd
@@ -105,6 +105,8 @@ func say(character: String, type: String, text: String) -> void:
 			var _manager: ESCDialogManager = load(_manager_class).new()
 			if _manager.has_type(type):
 				_dialog_manager = _manager
+			else:
+				_dialog_manager = null
 
 	if _dialog_manager == null:
 		escoria.logger.report_errors(

--- a/game/rooms/room01/esc/wall_item_popupdialog.esc
+++ b/game/rooms/room01/esc/wall_item_popupdialog.esc
@@ -9,5 +9,5 @@
 	stop
 > [eq dialog_popup_advance 2]
 	say player ROOM1_look_wall_item_3:"No, SERIOUSLY, I have no idea what that is!" avatar
-	say player ROOM1_look_wall_item_4:"Please stop asking me that!" avatar_dialog_player
+	say player ROOM1_look_wall_item_4:"Please stop asking me that!" avatar
 	stop


### PR DESCRIPTION
An underlying bug also existed where multiple `say` commands in the same event caused an issue if one of the subsequent `say` commands in said event used an invalid dialog player type. It looks like re-using the same player as such would throw an error with trying to connect the same signal (despite being a 'oneshot'), but this could be either because of a race condition or that the manager was being marked for deletion and not processed in a timely fashion.