### PR TITLE
Fix: disable ESCGame inputs until signal room_ready is emitted

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_game.gd
+++ b/addons/escoria-core/game/core-scripts/esc_game.gd
@@ -38,6 +38,11 @@ export(NodePath) var ui_parent_control_node
 # A reference to the node handling tooltips
 var tooltip_node: Object
 
+# Boolean indicating whether the game scene is ready to accept inputs 
+# from the player. This enables using escoria.is_ready_for_inputs() in _input()
+# function of game.gd script.
+var room_ready_for_inputs: bool = false
+
 
 # Function called when ESCGame enters the scene tree.
 func _enter_tree():
@@ -51,7 +56,12 @@ func _enter_tree():
 		self,
 		"_on_action_finished"
 	)
-	set_process_input(false)
+	
+	escoria.main.connect(
+		"room_ready", 
+		self, 
+		"_on_room_ready"
+	)
 
 
 # Function called when ESCGame exits the scene tree.
@@ -448,3 +458,8 @@ func escoria_show_ui():
 			"esc_game.gd#escoria_show_ui",
 			["UI parent Control node not defined!"]
 		)
+
+
+# Manage signal room_deady from main.gd.
+func _on_room_ready():
+	room_ready_for_inputs = true

--- a/addons/escoria-core/game/core-scripts/esc_game.gd
+++ b/addons/escoria-core/game/core-scripts/esc_game.gd
@@ -51,6 +51,7 @@ func _enter_tree():
 		self,
 		"_on_action_finished"
 	)
+	set_process_input(false)
 
 
 # Function called when ESCGame exits the scene tree.

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -391,8 +391,9 @@ func _handle_direct_scene_run() -> void:
 
 
 # Used by game.gd to determine whether the game scene is ready to take inputs
-# from _input() function. To do so, the current_scene must be set, game scene 
-# must be set and game scene must've been notified that room is ready.
+# from _input() function. To do so, the current_scene must be set, the game
+# scene must be set, and the game scene must've been notified that room
+# is ready.
 #
 # *Returns*
 # true if game scene is ready for inputs

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -391,8 +391,8 @@ func _handle_direct_scene_run() -> void:
 
 
 # Used by game.gd to determine whether the game scene is ready to take inputs
-# from _input() function. To do so, the current_scene must be set, the game
-# scene must be set, and the game scene must've been notified that room
+# from the _input() function. To do so, the current_scene must be set, the game
+# scene must be set, and the game scene must've been notified that the room
 # is ready.
 #
 # *Returns*

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -389,3 +389,13 @@ func _handle_direct_scene_run() -> void:
 	if current_scene_root is ESCRoom:
 		escoria.object_manager.set_current_room(current_scene_root)
 
+
+# Used by game.gd to determine whether the game scene is ready to take inputs
+# from _input() function. To do so, the current_scene must be set, game scene 
+# must be set and game scene must've been notified that room is ready.
+#
+# *Returns*
+# true if game scene is ready for inputs
+func is_ready_for_inputs() -> bool:
+	return escoria.main.current_scene and escoria.main.current_scene.game \
+			and escoria.main.current_scene.game.room_ready_for_inputs

--- a/addons/escoria-core/game/main.gd
+++ b/addons/escoria-core/game/main.gd
@@ -90,7 +90,6 @@ func set_scene_finish() -> void:
 	current_scene.visible = true
 
 	clear_previous_scene()
-	escoria.main.current_scene.game.set_process_input(true)
 	emit_signal("room_ready")
 	
 

--- a/addons/escoria-core/game/main.gd
+++ b/addons/escoria-core/game/main.gd
@@ -90,8 +90,9 @@ func set_scene_finish() -> void:
 	current_scene.visible = true
 
 	clear_previous_scene()
-
+	escoria.main.current_scene.game.set_process_input(true)
 	emit_signal("room_ready")
+	
 
 
 # Cleanup the previous scene if there was one.

--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -97,10 +97,10 @@ func _exit_tree():
 
 
 func _input(event: InputEvent) -> void:
-	if escoria.main.current_scene and escoria.main.current_scene.game:
-			if event is InputEventMouseMotion:
-				escoria.main.current_scene.game. \
-					update_tooltip_following_mouse_position(event.position)
+	if escoria.is_ready_for_inputs():
+		if event is InputEventMouseMotion:
+			escoria.main.current_scene.game. \
+				update_tooltip_following_mouse_position(event.position)
 
 
 # https://github.com/godotengine/godot-demo-projects/blob/3.4-585455e/misc/joypads/joypads.gd


### PR DESCRIPTION
Note: this bug happens on Godot 3.4.4, using simple-mouse plugin.

Fixes a crash happening when game scene was receiving inputs while changing the scene.