### PR TITLE
fix: allows for transitions to be disabled during :init event

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -84,8 +84,6 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 				if can_interrupt:
 					escoria.event_manager.interrupt_running_event()
 
-				self.clear_current_action()
-
 				var walk_fast = false
 				if params.size() > 2:
 					walk_fast = true if params[2] else false

--- a/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
@@ -282,8 +282,8 @@ func _on_event_finished(finished_statement: ESCStatement, return_code: int, chan
 		escoria.save_manager.save_enabled = true
 
 	if return_code == ESCExecution.RC_CANCEL:
-		return_code = ESCExecution.RC_OK
-
+	  return_code = ESCExecution.RC_OK
+	
 	_running_events[channel_name] = null
 	_channels_state[channel_name] = true
 

--- a/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
@@ -282,7 +282,7 @@ func _on_event_finished(finished_statement: ESCStatement, return_code: int, chan
 		escoria.save_manager.save_enabled = true
 
 	if return_code == ESCExecution.RC_CANCEL:
-	  return_code = ESCExecution.RC_OK
+		return_code = ESCExecution.RC_OK
 	
 	_running_events[channel_name] = null
 	_channels_state[channel_name] = true

--- a/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
@@ -113,7 +113,6 @@ func change_scene(room_path: String, enable_automatic_transitions: bool) -> void
 			var game_parent = escoria.game_scene.get_parent()
 			game_parent.remove_child(escoria.game_scene)
 
-		#escoria.game_scene.hide_ui()
 		room_scene.add_child(escoria.game_scene)
 		room_scene.move_child(escoria.game_scene, 0)
 		room_scene.game = escoria.game_scene

--- a/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
@@ -113,6 +113,7 @@ func change_scene(room_path: String, enable_automatic_transitions: bool) -> void
 			var game_parent = escoria.game_scene.get_parent()
 			game_parent.remove_child(escoria.game_scene)
 
+		#escoria.game_scene.hide_ui()
 		room_scene.add_child(escoria.game_scene)
 		room_scene.move_child(escoria.game_scene, 0)
 		room_scene.game = escoria.game_scene

--- a/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_room_manager.gd
@@ -223,10 +223,6 @@ func _perform_script_events(room: ESCRoom) -> void:
 
 		yielded = true
 
-		# Hide main and pause menus
-		escoria.game_scene.hide_main_menu()
-		escoria.game_scene.unpause_game()
-
 	# With the room transitioned out, finish any room prep and run :setup if
 	# it exists.
 	if room.player_scene:
@@ -305,6 +301,10 @@ func _perform_script_events(room: ESCRoom) -> void:
 	# Conclude the call to set_scene (thankyouverymuch, coroutines), including
 	# making the new room visible.
 	escoria.main.set_scene_finish()
+
+	# Hide main and pause menus
+	escoria.game_scene.hide_main_menu()
+	escoria.game_scene.unpause_game()
 
 	# Maybe this is ok to put in set_scene_finish() above? But it might be a bit
 	# confusing to not see the matching camera.current updates.

--- a/addons/escoria-core/game/core-scripts/esc_game.gd
+++ b/addons/escoria-core/game/core-scripts/esc_game.gd
@@ -31,6 +31,9 @@ export(float) var mouse_tooltip_margin = 50.0
 export(EDITOR_GAME_DEBUG_DISPLAY) var editor_debug_mode = \
 		EDITOR_GAME_DEBUG_DISPLAY.NONE setget _set_editor_debug_mode
 
+# The Control node underneath which all UI must be placed.
+# This should be a Control node and NOT a CanvasLayer (or any other type of) node.
+export(NodePath) var ui_parent_control_node
 
 # A reference to the node handling tooltips
 var tooltip_node: Object
@@ -421,3 +424,26 @@ func show_crash_popup(files: Array = []) -> void:
 	yield(crash_popup, "confirmed")
 	emit_signal("crash_popup_confirmed")
 
+
+# *** FOR USE BY ESCORIA CORE ONLY ***
+# Hides everything under the UI Control node.
+func escoria_hide_ui():
+	if ui_parent_control_node != null and not ui_parent_control_node.is_empty():
+		(get_node(ui_parent_control_node) as Control).visible = false
+	else:
+		escoria.logger.report_warnings(
+			"esc_game.gd#escoria_hide_ui",
+			["UI parent Control node not defined!"]
+		)
+
+
+# *** FOR USE BY ESCORIA CORE ONLY ***
+# Show everything under the UI Control node.
+func escoria_show_ui():
+	if ui_parent_control_node != null and not ui_parent_control_node.is_empty():
+		(get_node(ui_parent_control_node) as Control).visible = true
+	else:
+		escoria.logger.report_warnings(
+			"esc_game.gd#escoria_show_ui",
+			["UI parent Control node not defined!"]
+		)

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -172,6 +172,9 @@ func _notification(what):
 # Usually you'll want to show some logos animations before spawning the main
 # menu in the escoria/main/game_start_script 's :init event
 func init():
+	# Don't show the UI until we're ready in order to avoid a sometimes-noticeable
+	# blink. The UI will be "shown" later via a visibility update to the first room.
+	escoria.game_scene.escoria_hide_ui()
 	run_event_from_script(start_script, self.event_manager.EVENT_INIT)
 
 

--- a/addons/escoria-core/game/main.gd
+++ b/addons/escoria-core/game/main.gd
@@ -222,6 +222,8 @@ func check_game_scene_methods():
 
 	assert(current_scene.game.has_method("hide_ui"))
 	assert(current_scene.game.has_method("show_ui"))
+	assert(current_scene.game.has_method("escoria_hide_ui"))
+	assert(current_scene.game.has_method("escoria_show_ui"))
 	assert(current_scene.game.has_method("_on_event_done"))
 
 

--- a/addons/escoria-core/game/scenes/transitions/esc_transition_player.gd
+++ b/addons/escoria-core/game/scenes/transitions/esc_transition_player.gd
@@ -39,12 +39,9 @@ func _ready() -> void:
 	anchor_right = 1
 	anchor_bottom = 1
 	color = Color.white
+	color.a = 0
 	mouse_filter = MOUSE_FILTER_IGNORE
 	_tween = Tween.new()
-	add_child(_tween)
-	_tween.connect("tween_all_completed", self, "_on_tween_completed")
-
-	transition()
 
 
 # Play a transition animation
@@ -60,6 +57,14 @@ func transition(
 	mode: int = TRANSITION_MODE.IN,
 	duration: float = 1.0
 ) -> int:
+
+	# We put this here instead of the constructor since if we have it in the
+	# constructor, the transition will ALWAYS happen on game start, which might
+	# not be desired if 'false' is used for automatic_transitions in a
+	# change_scene call in :init.
+	if not _tween.is_inside_tree():
+		add_child(_tween)
+		_tween.connect("tween_all_completed", self, "_on_tween_completed")
 
 	if transition_name.empty():
 		transition_name = escoria.project_settings_manager.get_setting(

--- a/addons/escoria-ui-9verbs/game.gd
+++ b/addons/escoria-ui-9verbs/game.gd
@@ -347,8 +347,9 @@ func _on_action_finished() -> void:
 	tooltip.clear()
 
 func _on_event_done(_return_code: int, _event_name: String):
-	escoria.action_manager.clear_current_action()
-	verbs_menu.unselect_actions()
+	if _return_code == ESCExecution.RC_OK:
+		escoria.action_manager.clear_current_action()
+		verbs_menu.unselect_actions()
 
 
 func apply_custom_settings(custom_settings: Dictionary):

--- a/addons/escoria-ui-9verbs/game.tscn
+++ b/addons/escoria-ui-9verbs/game.tscn
@@ -16,6 +16,7 @@ bg_color = Color( 0.6, 0.6, 0.6, 0.5 )
 script = ExtResource( 5 )
 main_menu = NodePath("ui/main_menu")
 pause_menu = NodePath("ui/pause_menu")
+ui_parent_control_node = NodePath("ui/Control")
 
 [node name="dialog_layer" type="CanvasLayer" parent="."]
 
@@ -142,15 +143,6 @@ margin_right = 404.0
 margin_bottom = 200.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-
-[node name="hover_stack" type="Label" parent="ui"]
-margin_left = 1085.0
-margin_top = 2.81912
-margin_right = 1283.0
-margin_bottom = 107.819
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="main_menu" parent="ui" instance=ExtResource( 7 )]
 visible = false

--- a/addons/escoria-ui-keyboard-9verbs/game.tscn
+++ b/addons/escoria-ui-keyboard-9verbs/game.tscn
@@ -17,6 +17,7 @@ bg_color = Color( 0.6, 0.6, 0.6, 0.5 )
 script = ExtResource( 5 )
 main_menu = NodePath("ui/main_menu")
 pause_menu = NodePath("ui/pause_menu")
+ui_parent_control_node = NodePath("ui/Control")
 
 [node name="dialog_layer" type="CanvasLayer" parent="."]
 

--- a/addons/escoria-ui-simplemouse/game.tscn
+++ b/addons/escoria-ui-simplemouse/game.tscn
@@ -15,6 +15,7 @@ script = ExtResource( 5 )
 main_menu = NodePath("CanvasLayer/main_menu")
 pause_menu = NodePath("CanvasLayer/pause_menu")
 editor_debug_mode = 1
+ui_parent_control_node = NodePath("CanvasLayer/ui")
 
 [node name="camera" parent="." instance=ExtResource( 3 )]
 

--- a/game/rooms/intro/esc/intro.esc
+++ b/game/rooms/intro/esc/intro.esc
@@ -1,4 +1,4 @@
-:setup | NO_UI
+:setup
 anim_block intro_animation_player RESET
 
 :ready | NO_UI


### PR DESCRIPTION
Also does the following:

- Eliminates UI flicker during game startup
- Eliminates menu disappearing resulting in flicker of previous scene when transitioning to first scene during `:newgame`

These should be tested against saving and loading games when the system is back in working order.