### PR TITLE
fix: handles translation keys that have only one word (i.e. no spaces…

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
@@ -46,7 +46,9 @@ func _init(command_string):
 						parameters.append(
 							parameter
 						)
-					elif ":" in parameter and '"' in parameter and not parameter.ends_with('"'):
+					elif ':"' in parameter and (parameter.ends_with(':"') or not parameter.ends_with('"')):
+						# The second clause in this helps to handle dialogue that starts with a space
+						# and also allowing single-word dialogue to be handled in a separate elif.
 						quote_open = true
 						parameter_values.append(parameter)
 					elif not quote_open and parameter.begins_with('"'):

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
@@ -46,7 +46,7 @@ func _init(command_string):
 						parameters.append(
 							parameter
 						)
-					elif ":" in parameter and '"' in parameter:
+					elif ":" in parameter and '"' in parameter and not parameter.ends_with('"'):
 						quote_open = true
 						parameter_values.append(parameter)
 					elif not quote_open and parameter.begins_with('"'):


### PR DESCRIPTION
…) in the actual dialogue

Fixes https://github.com/godot-escoria/escoria-issues/issues/264
Fixes https://github.com/godot-escoria/escoria-issues/issues/267
Fixes https://github.com/godot-escoria/escoria-issues/issues/266