### PR TITLE
fix: Fix #168 as turn to in room 10 didn't work correctly

### DIFF
--- a/game/rooms/room10/esc/button_turn_to.esc
+++ b/game/rooms/room10/esc/button_turn_to.esc
@@ -2,8 +2,8 @@
 
 say player "Huh?"
 
-turn_to player r10_l_exit
+turn_to player left_door_location
 
 say player "Nothing."
 
-turn_to player r10_r_exit 0.2
+turn_to player right_door_location 0.2

--- a/game/rooms/room10/room10.tscn
+++ b/game/rooms/room10/room10.tscn
@@ -48,6 +48,7 @@ default_action = "walk"
 [node name="ESCLocation" type="Position2D" parent="Hotspots/r_door"]
 position = Vector2( 1228, 437 )
 script = ExtResource( 5 )
+global_id = "right_door_location"
 
 [node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="Hotspots/r_door"]
 polygon = PoolVector2Array( 1174, 122, 1280, 167, 1279, 482, 1173, 414 )
@@ -69,6 +70,7 @@ polygon = PoolVector2Array( 1, 482, 3, 166, 109, 124, 109, 413 )
 [node name="Position2D" type="Position2D" parent="Hotspots/l_door"]
 position = Vector2( 57, 437 )
 script = ExtResource( 5 )
+global_id = "left_door_location"
 
 [node name="button_stop_bg_music" type="Area2D" parent="Hotspots"]
 pause_mode = 1


### PR DESCRIPTION
fixes : https://github.com/godot-escoria/escoria-issues/issues/168

The description on that issue is old. We've since clarified how turn_to works in the documentation, so the room has been fixed to match.