### PR TITLE
fix: Fixes typo in say statement

### DIFF
--- a/game/rooms/room10/esc/button_accept_input_test.esc
+++ b/game/rooms/room10/esc/button_accept_input_test.esc
@@ -6,7 +6,7 @@ say player "Hello. I will now walk a bit and won't listen at what you say!"
 accept_input NONE
 walk_block player r10_player_start
 walk_block player accept_input_location
-say player "Ha! Now you can't even skip this text!" avatar_dialog_player
+say player "Ha! Now you can't even skip this text!" avatar
 accept_input SKIP
 say player "Okay, you can skip this text, but still not move me until 3 seconds have passed."
 wait 3


### PR DESCRIPTION
As it is, it throws the following error
```
ESC 2022-06-05T00:29:54 (D)    Running command say with parameters [player, "Ha! Now you can't even skip this text!", avatar_dialog_player]     
 ESC 2022-06-05T00:29:54 (E)    Errors in file esc_dialog_player.gd:say
No dialog manager supports the type avatar_dialog_player
```
Orion ("Dev Orion" on Discord, I'm not sure here on github) pointed out on Discord it's likely a typo. This is the change discussed there, which I tested and fixes the issue.