### PR TITLE
issue 283 - make inventory appear when running via f5. Hide options menu when pausing game.

### DIFF
--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -292,10 +292,13 @@ func mousewheel_action(direction: int):
 
 func hide_ui():
 	$CanvasLayer/ui/HBoxContainer/inventory_ui.hide()
+	$CanvasLayer/ui.hide()
 
 
 func show_ui():
 	$CanvasLayer/ui/HBoxContainer/inventory_ui.show()
+	$CanvasLayer/ui.show()
+
 
 func hide_main_menu():
 	if get_node(main_menu).visible:
@@ -316,6 +319,7 @@ func unpause_game():
 func pause_game():
 	if not get_node(pause_menu).visible:
 		get_node(main_menu).reset()
+		get_node(pause_menu).reset()
 		get_node(pause_menu).set_save_enabled(
 			escoria.save_manager.save_enabled
 		)


### PR DESCRIPTION
Simplemouse - inventory not showing, and options menu showing when it shouldn't when you pause the game.
Fixes https://github.com/godot-escoria/escoria-issues/issues/283