### PR TITLE
Issue 165 - no indication when destination is unreachable

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -540,6 +540,20 @@ func perform_inputevent_on_object(
 
 		if not player_global_pos.is_equal_approx(destination_position):
 			dont_interact = true
+			escoria.logger.info(
+				self,
+				"Player could not reach destination coordinates %s. "  % str(destination_position) \
+					+ "Any requested action for %s will not fire." % obj.global_id
+			)
+			if escoria.event_manager.EVENT_CANT_REACH in obj.events:
+				escoria.event_manager.queue_event(obj.events[escoria.event_manager.EVENT_CANT_REACH])
+			else:
+				escoria.logger.info(
+					self,
+					"%s event not found for object %s so nothing to do." % \
+						[escoria.event_manager.EVENT_CANT_REACH, obj.global_id]
+				)
+
 
 	# If no interaction should happen after player has arrived, leave
 	# immediately.

--- a/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
@@ -31,6 +31,7 @@ const EVENT_ROOM_SELECTOR = "room_selector"
 const EVENT_SETUP = "setup"
 const EVENT_TRANSITION_IN = "transition_in"
 const EVENT_TRANSITION_OUT = "transition_out"
+const EVENT_CANT_REACH = "cant_reach"
 
 
 # Event channel names


### PR DESCRIPTION
I'm not sure if this is the right way to solve this problem with scheduling events etc, but it looked right to me and worked for my testing.

To test, take an item (eg. the left hand painting in room 1) and move its related ESCLocation out of the navigation polygon.

Standard behavior is a warning debug message.
If you add a "cant_reach" event to the object's script, this will fire. e.g.
```
:cant_reach
say player "Sorry, I can't reach the painting."
```
Fixes https://github.com/godot-escoria/escoria-issues/issues/165