### PR TITLE
fix: fixes inconsistent return type from queue_event_from_esc

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
@@ -184,12 +184,12 @@ func queue_event_from_esc(script_object: ESCScript, event: String,
 			var rc = yield(self, "event_finished")
 			while rc[1] != event:
 				rc = yield(self, "event_finished")
-			return rc
+			return rc[0]
 		else:
 			var rc = yield(self, "background_event_finished")
 			while rc[1] != event and rc[2] != channel:
 				rc = yield(self, "background_event_finished")
-			return rc
+			return rc[0]
 
 	return ESCExecution.RC_OK
 

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_command.gd
@@ -130,6 +130,7 @@ func run() -> int:
 			var rc = command_object.run(prepared_arguments)
 			if rc is GDScriptFunctionState:
 				rc = yield(rc, "completed")
+			
 			escoria.logger.debug(
 				self,
 				"[%s] Return code: %d." % [self.name, rc]

--- a/game/rooms/room14/esc/button_main_menu.esc
+++ b/game/rooms/room14/esc/button_main_menu.esc
@@ -11,3 +11,5 @@ wait 2
 # Hide main menu, automatic transitions ENABLED
 hide_menu main true
 
+:look
+say player "button main menu"

--- a/game/rooms/room14/esc/button_main_menu_change_scene.esc
+++ b/game/rooms/room14/esc/button_main_menu_change_scene.esc
@@ -36,3 +36,6 @@ wait 1
 change_scene res://game/rooms/room14/room14.tscn false
 
 # Do not transition here either, as change_scene ends the execution of this script
+
+:look
+say player "Button change scene"

--- a/game/rooms/room14/esc/button_main_menu_change_scene_auto.esc
+++ b/game/rooms/room14/esc/button_main_menu_change_scene_auto.esc
@@ -26,3 +26,5 @@ wait 2
 change_scene res://game/rooms/room14/room14.tscn
 
 
+:look
+say player "Button change scene auto"

--- a/game/rooms/room14/esc/button_pause_menu.esc
+++ b/game/rooms/room14/esc/button_pause_menu.esc
@@ -11,3 +11,6 @@ wait 2
 # Hide pause menu, automatic transition are disabled by default
 # So we can manage them manually using `transition` ESC command
 hide_menu pause
+
+:look
+say player "Button pause menu"

--- a/game/rooms/room14/esc/room14.esc
+++ b/game/rooms/room14/esc/room14.esc
@@ -36,4 +36,12 @@
 
 
 :ready
-	queue_event worker moveworker
+# Both events will queue one after the other. As event "moveworker" features 
+# both a blocking and non-blocking command, the blocking command will block
+# until it's finished. At this point, moveworker2's event will fire. 
+# The end result is that you'll see worker1 start moving while the player
+# speaks, and once the say command concludes, worker 2 will start walking.
+	queue_event worker moveworker _queuedemo true
+	queue_event worker2 moveworker2 _queuedemo
+
+	

--- a/game/rooms/room14/esc/worker.esc
+++ b/game/rooms/room14/esc/worker.esc
@@ -1,2 +1,8 @@
 :moveworker
+	# Non-blocking command
 	walk worker worker_target
+	
+	# Blocking command. This will block the queued walk event following this 
+	# (as specified in room14.esc) from starting until this command has
+	# completed.
+	say player "Blocking"

--- a/game/rooms/room14/esc/worker2.esc
+++ b/game/rooms/room14/esc/worker2.esc
@@ -1,0 +1,3 @@
+:moveworker2
+	# Non-blocking command
+	walk worker2 worker2_target

--- a/game/rooms/room14/room14.tscn
+++ b/game/rooms/room14/room14.tscn
@@ -57,6 +57,7 @@ esc_script = "res://game/rooms/room14/esc/left_exit.esc"
 is_exit = true
 tooltip_name = "Left exit"
 default_action = "walk"
+combine_when_selected_action_is_in = [  ]
 dialog_color = Color( 1, 1, 1, 1 )
 animations = null
 
@@ -71,6 +72,7 @@ global_id = "r12_l_exit"
 [node name="r_door" parent="Hotspots" instance=ExtResource( 8 )]
 global_id = "r14_r_exit"
 esc_script = "res://game/rooms/room14/esc/right_exit.esc"
+combine_when_selected_action_is_in = [  ]
 
 [node name="ESCLocation" type="Position2D" parent="Hotspots/r_door"]
 position = Vector2( 1231.78, 360.624 )
@@ -86,6 +88,7 @@ interaction_direction = 180
 [node name="show_main_menu" parent="." instance=ExtResource( 9 )]
 global_id = "button_main_menu"
 esc_script = "res://game/rooms/room14/esc/button_main_menu.esc"
+combine_when_selected_action_is_in = [  ]
 
 [node name="ESCLocation" type="Position2D" parent="show_main_menu"]
 position = Vector2( 343.887, 381.305 )
@@ -109,6 +112,7 @@ __meta__ = {
 position = Vector2( 233.415, 0 )
 global_id = "button_pause_menu"
 esc_script = "res://game/rooms/room14/esc/button_pause_menu.esc"
+combine_when_selected_action_is_in = [  ]
 
 [node name="ESCLocation" type="Position2D" parent="show_pause_menu"]
 position = Vector2( 343.887, 381.305 )
@@ -123,14 +127,12 @@ text = "Show pause menu
 with NO transition
 (manual or automatic)"
 align = 1
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="show_pause_change_scene_manual" parent="." instance=ExtResource( 9 )]
 position = Vector2( 463.318, 0 )
 global_id = "button_main_change_scene"
 esc_script = "res://game/rooms/room14/esc/button_main_menu_change_scene.esc"
+combine_when_selected_action_is_in = [  ]
 
 [node name="ESCLocation" type="Position2D" parent="show_pause_change_scene_manual"]
 position = Vector2( 343.887, 381.305 )
@@ -154,6 +156,7 @@ __meta__ = {
 position = Vector2( 676.318, 0 )
 global_id = "button_pause_change_scene_auto"
 esc_script = "res://game/rooms/room14/esc/button_main_menu_change_scene_auto.esc"
+combine_when_selected_action_is_in = [  ]
 
 [node name="ESCLocation" type="Position2D" parent="show_pause_change_scene_auto"]
 position = Vector2( 343.887, 381.305 )
@@ -176,8 +179,20 @@ __meta__ = {
 [node name="worker" parent="." instance=ExtResource( 10 )]
 position = Vector2( 204.268, 376.233 )
 esc_script = "res://game/rooms/room14/esc/worker.esc"
+combine_when_selected_action_is_in = [  ]
+
+[node name="worker2" parent="." instance=ExtResource( 10 )]
+position = Vector2( 726, 390 )
+global_id = "worker2"
+esc_script = "res://game/rooms/room14/esc/worker2.esc"
+combine_when_selected_action_is_in = [  ]
 
 [node name="worker_target" type="Position2D" parent="."]
 position = Vector2( 917.51, 475.808 )
 script = ExtResource( 5 )
 global_id = "worker_target"
+
+[node name="worker_target2" type="Position2D" parent="."]
+position = Vector2( 513, 472 )
+script = ExtResource( 5 )
+global_id = "worker2_target"


### PR DESCRIPTION
Expands on the queue_event demo in room 14 by adding a second worker. It shows what happens when two events are queued and one contains a blocking command.
It also corrects issues with the return code from the queue_event command when a queue and blocking parameter are provided (thanks @BHSDuncan!)
