### PR TITLE
fix: Support for both int and real for set_angle command

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/set_angle.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/set_angle.gd
@@ -22,7 +22,7 @@ class_name SetAngleCommand
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
 		2,
-		[TYPE_STRING, TYPE_INT, TYPE_REAL],
+		[TYPE_STRING,  [TYPE_REAL, TYPE_INT],  [TYPE_REAL, TYPE_INT]],
 		[null, null, 0.0]
 	)
 


### PR DESCRIPTION
Support for both real and int to be accepted for the angle for the player to face, and for the amount of time the character will face each intervening direction as they turn. Currently only ints are allowed for direction, and real for wait time.

Questions for discussion
1) Duration is expected to be a real, but I used an int. This is easily fixed by just changing the validate function to 
[TYPE_STRING,  TYPE_INT,  [TYPE_REAL, TYPE_INT]]. 

The second parmeter is the angle you want the player to face. I've tested and this also works as a real, i.e.
[TYPE_STRING,  [TYPE_REAL, TYPE_INT],  [TYPE_REAL, TYPE_INT]],

So can anyone see a reason the developer shouldn't be allowed to specify an angle as a real? I can't see anyone ever needing it, but at least it wouldn't break things if they accidently used a real
2) The function definition says
> - *degrees*: Number of degrees by which `object` is to be turned

Testing shows that this is incorrect. The behavior is actually that the angle specified is the angle the character will end up facing. So which is correct?
3) If the final angle is 180 degrees away from where you want it to be, or you want the character to turn the long way, this isn't possible. Should we have a way of specifying clockwise/anti-clockwise rotation?

4) To see which frames of the animation would play during the turn, I added some additional frames to the idle directions before testing. I noticed some unexpected behavior with this script while testing if the set_angle was blocking
    say player "It's a leaking pipe."
    set_angle player 270 2.0
    say player "Nooooooooooo."
    set_global r5_dialog_advance 1

He says the first line, then starts the turn. As set_angle isn't blocking, he immediately says the second line, turns to 270 for a split seconds, then ends up facing back upwards again - something to do with the 2 second timing.
So should this command be blocking? A blocking and non-blocking version might be a good idea, but I'm not sure how we treat the behavior in my example
5) From my (4) example, it appears the first 2 second pause is facing the direction he's already facing (upwards). Does this seem right. It probably won't matter in 99% of cases as I'd expect developers to set the duration to 0.1 or something so the character can be seen to turn rather than immediately facing the new direction. Larger numbers don't serve much purpose (that doesn't mean we shouldn't support them though as you might want a game character to do a very slow, dramatic turn). 