### PR TITLE
fix: Stops error message when disabling simple dialog plugin

### DIFF
--- a/addons/escoria-core/game/esc_project_settings_manager.gd
+++ b/addons/escoria-core/game/esc_project_settings_manager.gd
@@ -84,9 +84,6 @@ const FULLSCREEN = "%s/%s/%s/fullscreen" % [DISPLAY, WINDOW, SIZE]
 # - default_value: Default value
 # - info: Property info for the setting
 static func register_setting(name: String, default_value, info: Dictionary) -> void:
-	if ProjectSettings.has_setting(name):
-		push_error("Cannot add project setting %s - it already exists." % name)
-		return
 	if default_value == null:
 		push_error("Default_value cannot be null. Use remove_setting function to remove settings.")
 		assert(false)

--- a/addons/escoria-core/game/esc_project_settings_manager.gd
+++ b/addons/escoria-core/game/esc_project_settings_manager.gd
@@ -81,15 +81,42 @@ const FULLSCREEN = "%s/%s/%s/fullscreen" % [DISPLAY, WINDOW, SIZE]
 # #### Parameters
 #
 # - name: Name of the project setting
-# - default: Default value
+# - default_value: Default value
 # - info: Property info for the setting
-static func register_setting(name: String, default, info: Dictionary) -> void:
+static func register_setting(name: String, default_value, info: Dictionary) -> void:
+	if ProjectSettings.has_setting(name):
+		push_error("Cannot add project setting %s - it already exists." % name)
+		return
+	if default_value == null:
+		push_error("Default_value cannot be null. Use remove_setting function to remove settings.")
+		assert(false)
+
 	ProjectSettings.set_setting(
 		name,
-		default
+		default_value
 	)
-	info.name = name
-	ProjectSettings.add_property_info(info)
+	if default_value != null:
+		info.name = name
+		
+		# Project settings require a "type" to be set
+		if not "type" in info:
+			info.type=typeof(default_value)
+		ProjectSettings.add_property_info(info)
+
+
+# Removes the specified project setting.
+#
+# #### Parameters
+#
+# - name: Name of the project setting
+static func remove_setting(name: String) -> void:
+	if not ProjectSettings.has_setting(name):
+		push_error("Cannot remove project setting %s - it does not exist." % name)
+		assert(false)
+	ProjectSettings.set_setting(
+			name,
+			null
+		)
 
 
 # Retrieves the specified project setting.

--- a/addons/escoria-core/plugin.gd
+++ b/addons/escoria-core/plugin.gd
@@ -68,15 +68,6 @@ func _enter_tree():
 # Prepare the settings in the Escoria UI category
 func set_escoria_ui_settings():
 	register_setting(
-		ESCProjectSettingsManager.DEFAULT_DIALOG_TYPE,
-		"",
-		{
-			"type": TYPE_STRING
-		}
-	)
-	print("DEFAULT DIALOG TYPE RESET !!!")
-
-	register_setting(
 		ESCProjectSettingsManager.GAME_SCENE,
 		"",
 		{

--- a/addons/escoria-dialog-simple/plugin.gd
+++ b/addons/escoria-dialog-simple/plugin.gd
@@ -13,33 +13,24 @@ func get_plugin_name():
 # Unregister ourselves
 func disable_plugin():
 	print("Disabling plugin Escoria Dialog Simple")
-	ESCProjectSettingsManager.register_setting(
-		ESCProjectSettingsManager.DEFAULT_DIALOG_TYPE,
-		"",
-		{}
+	ESCProjectSettingsManager.remove_setting(
+		ESCProjectSettingsManager.DEFAULT_DIALOG_TYPE
 	)
-	ESCProjectSettingsManager.register_setting(
-		ESCProjectSettingsManager.AVATARS_PATH,
-		null,
-		{}
+	
+	ESCProjectSettingsManager.remove_setting(
+		ESCProjectSettingsManager.AVATARS_PATH
 	)
 
-	ESCProjectSettingsManager.register_setting(
-		ESCProjectSettingsManager.TEXT_SPEED_PER_CHARACTER,
-		null,
-		{}
+	ESCProjectSettingsManager.remove_setting(
+		ESCProjectSettingsManager.TEXT_SPEED_PER_CHARACTER
 	)
 
-	ESCProjectSettingsManager.register_setting(
-		ESCProjectSettingsManager.FAST_TEXT_SPEED_PER_CHARACTER,
-		null,
-		{}
+	ESCProjectSettingsManager.remove_setting(
+		ESCProjectSettingsManager.FAST_TEXT_SPEED_PER_CHARACTER
 	)
 
-	ESCProjectSettingsManager.register_setting(
-		ESCProjectSettingsManager.MAX_TIME_TO_DISAPPEAR,
-		null,
-		{}
+	ESCProjectSettingsManager.remove_setting(
+		ESCProjectSettingsManager.MAX_TIME_TO_DISAPPEAR
 	)
 
 	EscoriaPlugin.deregister_dialog_manager(MANAGER_CLASS)


### PR DESCRIPTION
You'll see this error if disabling the simple dialog plugin.
```
 core/project_settings.cpp:961 - Condition "!p_info.has("type")" is true.
```
For every time an empty dictionary is passed to clear a setting from Godot's project settings in simple dialog

```
	ESCProjectSettingsManager.register_setting(
		ESCProjectSettingsManager.MAX_TIME_TO_DISAPPEAR,
		null,
		{}
	)
```