### PR TITLE
fix: Removing dialog settings from core

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/say.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/say.gd
@@ -78,13 +78,6 @@ func validate(arguments: Array):
 		)
 		return false
 
-	if ESCProjectSettingsManager.get_setting(ESCProjectSettingsManager.DEFAULT_DIALOG_TYPE) == "" \
-			and arguments[2] == "":
-		escoria.logger.error(
-			self,
-			"[%s]: Project setting '%s' is not set. Please set a default dialog type."
-					% [get_command_name(), ESCProjectSettingsManager.DEFAULT_DIALOG_TYPE]
-		)
 	return true
 
 

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -422,7 +422,6 @@ func save_settings():
 	settings_res.sfx_volume = escoria.settings.sfx_volume
 	settings_res.speech_volume = escoria.settings.speech_volume
 	settings_res.fullscreen = escoria.settings.fullscreen
-	settings_res.skip_dialog = escoria.settings.skip_dialog
 	settings_res.custom_settings = escoria.settings.custom_settings
 
 	var directory: Directory = Directory.new()

--- a/addons/escoria-core/game/core-scripts/save_data/esc_savesettings.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_savesettings.gd
@@ -41,8 +41,5 @@ export var speech_volume: float = ProjectSettings.get_setting(
 # True if game has to be fullscreen
 export var fullscreen: bool = false
 
-# True if skipping dialogs is allowed
-export var skip_dialogs: bool = true
-
 # Dictionary containing all user-defined settings.
 export var custom_settings: Dictionary

--- a/addons/escoria-core/game/core-scripts/save_data/esc_settings_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_settings_manager.gd
@@ -103,10 +103,6 @@ func save_settings_resource_to_project_settings(settings: ESCSaveSettings):
 		ESCProjectSettingsManager.FULLSCREEN,
 		settings.fullscreen
 	)
-	ESCProjectSettingsManager.set_setting(
-		ESCProjectSettingsManager.SKIP_DIALOGS,
-		settings.skip_dialogs
-	)
 	custom_settings = settings.custom_settings
 
 
@@ -157,12 +153,11 @@ func get_settings() -> ESCSaveSettings:
 	settings.fullscreen = ESCProjectSettingsManager.get_setting(
 		ESCProjectSettingsManager.FULLSCREEN
 	)
-	settings.skip_dialogs = ESCProjectSettingsManager.get_setting(
-		ESCProjectSettingsManager.SKIP_DIALOGS
-	)
 	settings.custom_settings = custom_settings
+	
 	return settings
 
+	
 
 # Save the game settings in the settings file.
 func save_settings():

--- a/addons/escoria-core/game/esc_project_settings_manager.gd
+++ b/addons/escoria-core/game/esc_project_settings_manager.gd
@@ -16,7 +16,7 @@ const GAME_SCENE = "%s/%s/game_scene" % [_ESCORIA_SETTINGS_ROOT, _UI_ROOT]
 const INVENTORY_ITEM_SIZE = "%s/%s/inventory_item_size" % [_ESCORIA_SETTINGS_ROOT, _UI_ROOT]
 const INVENTORY_ITEMS_PATH = "%s/%s/inventory_items_path" % [_ESCORIA_SETTINGS_ROOT, _UI_ROOT]
 const TRANSITION_PATHS = "%s/%s/transition_paths" % [_ESCORIA_SETTINGS_ROOT, _UI_ROOT]
-const SKIP_DIALOGS = "%s/%s/skip_dialogs" % [_ESCORIA_SETTINGS_ROOT, _UI_ROOT]
+
 
 # Main Escoria project settings
 const _MAIN_ROOT = "main"
@@ -61,15 +61,6 @@ const _PLATFORM_ROOT = "platform"
 const SKIP_CACHE = "%s/%s/skip_cache" % [_ESCORIA_SETTINGS_ROOT, _PLATFORM_ROOT]
 const SKIP_CACHE_MOBILE = "%s/%s/skip_cache.mobile" % [_ESCORIA_SETTINGS_ROOT, _PLATFORM_ROOT]
 
-# Simple dialog-related Escoria project settings
-const _SIMPLE_DIALOG_ROOT = "dialog_simple"
-
-const AVATARS_PATH = "%s/%s/avatars_path" % [_ESCORIA_SETTINGS_ROOT, _SIMPLE_DIALOG_ROOT]
-const TEXT_SPEED_PER_CHARACTER = "%s/%s/text_speed_per_character" % [_ESCORIA_SETTINGS_ROOT, _SIMPLE_DIALOG_ROOT]
-const FAST_TEXT_SPEED_PER_CHARACTER = "%s/%s/fast_text_speed_per_character" % [_ESCORIA_SETTINGS_ROOT, _SIMPLE_DIALOG_ROOT]
-const READING_SPEED_IN_WPM = "%s/%s/reading_speed_in_wpm" % [_ESCORIA_SETTINGS_ROOT, _SIMPLE_DIALOG_ROOT]
-
-
 # Godot Windows project settings
 const DISPLAY = "display"
 const WINDOW = "window"
@@ -82,15 +73,39 @@ const FULLSCREEN = "%s/%s/%s/fullscreen" % [DISPLAY, WINDOW, SIZE]
 # #### Parameters
 #
 # - name: Name of the project setting
-# - default: Default value
+# - default_value: Default value
 # - info: Property info for the setting
-static func register_setting(name: String, default, info: Dictionary) -> void:
+static func register_setting(name: String, default_value, info: Dictionary) -> void:
+	if default_value == null:
+		push_error("Default_value cannot be null. Use remove_setting function to remove settings.")
+		assert(false)
+		
 	ProjectSettings.set_setting(
 		name,
-		default
+		default_value
 	)
-	info.name = name
-	ProjectSettings.add_property_info(info)
+	if default_value != null:
+		info.name = name
+
+		# Project settings require a "type" to be set
+		if not "type" in info:
+			info.type=typeof(default_value)
+		ProjectSettings.add_property_info(info)
+
+
+# Removes the specified project setting.
+#
+# #### Parameters
+#
+# - name: Name of the project setting
+static func remove_setting(name: String) -> void:
+	if not ProjectSettings.has_setting(name):
+		push_error("Cannot remove project setting %s - it does not exist." % name)
+		assert(false)
+	ProjectSettings.set_setting(
+			name,
+			null
+		)
 
 
 # Retrieves the specified project setting.

--- a/addons/escoria-core/plugin.gd
+++ b/addons/escoria-core/plugin.gd
@@ -404,6 +404,9 @@ func set_escoria_platform_settings():
 # - info: Property info for the setting
 static func register_setting(name: String, default, info: Dictionary) -> void:
 	if not ProjectSettings.has_setting(name):
+		# Only core settings should set this to true. Settings configured in
+		# plugins should not set this to true.
+		info["core_setting"] = "true"
 		ProjectSettings.set_setting(
 			name,
 			default

--- a/addons/escoria-dialog-simple/plugin.gd
+++ b/addons/escoria-dialog-simple/plugin.gd
@@ -3,7 +3,14 @@ tool
 extends EditorPlugin
 
 const MANAGER_CLASS="res://addons/escoria-dialog-simple/esc_dialog_simple.gd"
+const SETTINGS_ROOT="escoria/dialog_simple"
 
+const AVATARS_PATH = "%s/avatars_path" % SETTINGS_ROOT
+const TEXT_SPEED_PER_CHARACTER = "%s/text_speed_per_character" % SETTINGS_ROOT
+const FAST_TEXT_SPEED_PER_CHARACTER = "%s/fast_text_speed_per_character" % SETTINGS_ROOT
+const MAX_TIME_TO_DISAPPEAR = "%s/max_time_to_disappear" % SETTINGS_ROOT
+const SKIP_DIALOGS = "%s/skip_dialogs" % SETTINGS_ROOT
+const READING_SPEED_IN_WPM = "%s/reading_speed_in_wpm" % SETTINGS_ROOT
 
 # Override function to return the plugin name.
 func get_plugin_name():
@@ -13,41 +20,37 @@ func get_plugin_name():
 # Unregister ourselves
 func disable_plugin():
 	print("Disabling plugin Escoria Dialog Simple")
-	ESCProjectSettingsManager.register_setting(
-		ESCProjectSettingsManager.DEFAULT_DIALOG_TYPE,
-		"",
-		{}
+	ESCProjectSettingsManager.remove_setting(
+		ESCProjectSettingsManager.DEFAULT_DIALOG_TYPE
 	)
-	ESCProjectSettingsManager.register_setting(
-		ESCProjectSettingsManager.AVATARS_PATH,
-		null,
-		{}
+	
+	ESCProjectSettingsManager.remove_setting(
+		AVATARS_PATH
 	)
 
-	ESCProjectSettingsManager.register_setting(
-		ESCProjectSettingsManager.TEXT_SPEED_PER_CHARACTER,
-		null,
-		{}
+	ESCProjectSettingsManager.remove_setting(
+		TEXT_SPEED_PER_CHARACTER
 	)
 
-	ESCProjectSettingsManager.register_setting(
-		ESCProjectSettingsManager.FAST_TEXT_SPEED_PER_CHARACTER,
-		null,
-		{}
+	ESCProjectSettingsManager.remove_setting(
+		FAST_TEXT_SPEED_PER_CHARACTER
 	)
 
-	ESCProjectSettingsManager.register_setting(
-		ESCProjectSettingsManager.READING_SPEED_IN_WPM,
-		null,
-		{}
+	ESCProjectSettingsManager.remove_setting(
+		READING_SPEED_IN_WPM
 	)
 
+	ESCProjectSettingsManager.remove_setting(
+		MAX_TIME_TO_DISAPPEAR
+	)
+	
 	EscoriaPlugin.deregister_dialog_manager(MANAGER_CLASS)
 
 
 # Add ourselves to the list of dialog managers
 func enable_plugin():
 	print("Enabling plugin Escoria Dialog Simple")
+
 	if EscoriaPlugin.register_dialog_manager(self, MANAGER_CLASS):
 		ESCProjectSettingsManager.register_setting(
 			ESCProjectSettingsManager.DEFAULT_DIALOG_TYPE,
@@ -58,8 +61,8 @@ func enable_plugin():
 		)
 
 		ESCProjectSettingsManager.register_setting(
-			ESCProjectSettingsManager.AVATARS_PATH,
-			"",
+			AVATARS_PATH,
+			"res://game/dialog_avatars",
 			{
 				"type": TYPE_STRING,
 				"hint": PROPERTY_HINT_DIR
@@ -67,7 +70,7 @@ func enable_plugin():
 		)
 
 		ESCProjectSettingsManager.register_setting(
-			ESCProjectSettingsManager.TEXT_SPEED_PER_CHARACTER,
+			TEXT_SPEED_PER_CHARACTER,
 			0.1,
 			{
 				"type": TYPE_REAL
@@ -75,7 +78,7 @@ func enable_plugin():
 		)
 
 		ESCProjectSettingsManager.register_setting(
-			ESCProjectSettingsManager.FAST_TEXT_SPEED_PER_CHARACTER,
+			FAST_TEXT_SPEED_PER_CHARACTER,
 			0.25,
 			{
 				"type": TYPE_REAL
@@ -83,12 +86,29 @@ func enable_plugin():
 		)
 
 		ESCProjectSettingsManager.register_setting(
-			ESCProjectSettingsManager.READING_SPEED_IN_WPM,
+			READING_SPEED_IN_WPM,
 			200,
 			{
 				"type": TYPE_INT
 			}
 		)
+
+		ESCProjectSettingsManager.register_setting(
+			MAX_TIME_TO_DISAPPEAR,
+			1.0,
+			{
+				"type": TYPE_INT
+			}
+		)
+
+		ESCProjectSettingsManager.register_setting(
+			SKIP_DIALOGS,
+			true,
+			{
+				"type": TYPE_BOOL
+			}
+		)
+		#escoria.settings_manager.custom_settings[SKIP_DIALOGS] = true
 	else:
 		get_editor_interface().set_plugin_enabled(
 			get_plugin_name(),

--- a/addons/escoria-wizard/plugin.gd
+++ b/addons/escoria-wizard/plugin.gd
@@ -43,10 +43,8 @@ func open_scene(path: String) -> void:
 # Unregister ourselves
 func disable_plugin():
 	print("Disabling Escoria Wizard plugin")
-	ESCProjectSettingsManager.register_setting(
-		"escoria/wizard/path_to_rooms",
-		null,
-		{}
+	ESCProjectSettingsManager.remove_setting(
+		"escoria/wizard/path_to_rooms"
 	)
 
 # Register ourselves


### PR DESCRIPTION
This PR is to separate dialog settings from core to make the dialog plugin standalone.
This also fixes the error messages seen when disabling and enabling core relating to info.type missing in the call in esc_project_settings_manager