### PR TITLE
fix: Turn interrupt warning to debug in change_scene.gd

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
@@ -74,7 +74,7 @@ func run(command_params: Array) -> int:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)


### PR DESCRIPTION
Changes warning :
W change_scene.gd: [change_scene] interrupt() function not implemented
to debug as discussed in https://discordapp.com/channels/884336424780984330/884346430314143745/1039283919255781456