### PR TITLE
fix: interrupt not implemented messages changed to debug from warn

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/anim.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/anim.gd
@@ -55,7 +55,7 @@ func run(command_params: Array) -> int:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/anim_block.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/anim_block.gd
@@ -61,7 +61,7 @@ func run(command_params: Array) -> int:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_push.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_push.gd
@@ -94,7 +94,7 @@ func run(command_params: Array) -> int:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_limits.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_limits.gd
@@ -58,7 +58,7 @@ func run(command_params: Array) -> int:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_pos.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_pos.gd
@@ -51,7 +51,7 @@ func run(command_params: Array) -> int:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_target.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_target.gd
@@ -54,7 +54,7 @@ func run(command_params: Array) -> int:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom.gd
@@ -40,7 +40,7 @@ func run(command_params: Array) -> int:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom_height.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_set_zoom_height.gd
@@ -52,7 +52,7 @@ func run(command_params: Array) -> int:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/camera_shift.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/camera_shift.gd
@@ -88,7 +88,7 @@ func validate(arguments: Array):
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/change_scene.gd
@@ -74,7 +74,7 @@ func run(command_params: Array) -> int:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/custom.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/custom.gd
@@ -94,7 +94,7 @@ func run(command_params: Array) -> int:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/say.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/say.gd
@@ -121,7 +121,7 @@ func run(command_params: Array) -> int:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)

--- a/addons/escoria-core/game/core-scripts/esc/commands/turn_to.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/turn_to.gd
@@ -73,7 +73,7 @@ func run(command_params: Array) -> int:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.warn(
+	escoria.logger.debug(
 		self,
 		"[%s] interrupt() function not implemented." % get_command_name()
 	)

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_base_command.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_base_command.gd
@@ -50,7 +50,7 @@ func get_command_name() -> String:
 
 # Function called when the command is interrupted.
 func interrupt():
-	escoria.logger.trace(
+	escoria.logger.debug(
 		self,
 		"Command %s did not override interrupt. Please implement an interrupt() function." % get_command_name()
 	)


### PR DESCRIPTION
Updated version of previous PR to include changing all messages for "interrupt() function not implemented." from warning to debug level.

I'm not sure if the message in addons/escoria-core/game/core-scripts/esc/types/esc_base_command.gd should be a stronger warning level (error maybe?) 