### PR TITLE
fix: returns an appropriate RC code when no more options are left at …

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
@@ -90,9 +90,17 @@ func run():
 		escoria.dialog_player,
 		"option_chosen"
 	) as ESCDialogOption
-	var rc = option.run()
-	if rc is GDScriptFunctionState:
-		rc = yield(rc, "completed")
-	if rc != ESCExecution.RC_CANCEL:
-		return self.run()
+
+	var rc = ESCExecution.RC_OK
+
+	# If no valid option was returned, it means this level of dialog is done.
+	# If this is the case and the current level of dialog has a parent, it means
+	# it is still yielding and so will be shown again.
+	if option:
+		rc = option.run()
+		if rc is GDScriptFunctionState:
+			rc = yield(rc, "completed")
+		if rc != ESCExecution.RC_CANCEL:
+			return self.run()
+
 	return rc

--- a/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_dialog.gd
@@ -80,7 +80,11 @@ func run():
 		self,
 		"Starting dialog."
 	)
+
+	# Since we're changing state, we need to remember and reset it once we're done
+	var previous_state = escoria.current_state
 	escoria.current_state = escoria.GAME_STATE.DIALOG
+
 	if !escoria.dialog_player:
 		escoria.dialog_player = escoria.main.current_scene.get_node(
 			"game/ui/dialog_layer/dialog_player"
@@ -102,5 +106,7 @@ func run():
 			rc = yield(rc, "completed")
 		if rc != ESCExecution.RC_CANCEL:
 			return self.run()
+
+	escoria.current_state = previous_state
 
 	return rc

--- a/game/rooms/room06/esc/worker.esc
+++ b/game/rooms/room06/esc/worker.esc
@@ -7,42 +7,53 @@ say player "I don't think he'd like that."
 
 ####################################################################################################
 :talk
+# This block will only execute once per game
 > [!talked_once]
 	turn_to worker player
-	say player "Hi."
-	say worker "Have you come about the job?"
+	say worker "If you talk to me again"
+	say worker "I will not say this opening sentence."
 	set_global talked_once true
 
+# Reset flag so the Loom conversation will be available every time 
+# you restart the conversation with the worker during a game.
+# The Loom inner conversation block will exit back to the outer question block
+# once all options are exhausted, which is why all of them have a conditional
+# flag to make them disappear once you choose
+# "I don't want to talk at all any more"
+
+set_global loom_conversation_done false
 turn_to worker player
 ?
-	- "What job are you hiring for?"
-		say player 	"What job are you hiring for?"
-		say worker 	"We're recruiting adventurers!"
+	- "What is your name?"
+		say current_player "Who are you?"
+		say worker "I'm the worker" [!name_known]
+		say worker "You already asked me that" [name_known]
+		set_global name_known true
+	- "Why are you here?"
+		say current_player "Why are you here?"
+		say worker "I'm waiting for you to give me the"
+		say worker "filled form from room 5."
+	# This starts an inner subset of questions
+	- "Can I ask you about Loom?" [!loom_conversation_done]
+		say current_player 	"What do you know about Loom?"
+		say worker "What do you want to know about Loom?"
 		?
-		- "Why would I want to be an adventurer?"
-			say player	"Why would I want to be an adventurer?"
-			say worker	"Fame!"
-			say worker	"Adventure!"
-			say worker	"Almost certain death!"
-		- "How do I apply?"
-			say player	"How do I apply?"
-			say worker	"All you need to do is find an ..."
-			say worker	"adventurer application form and fill it in"
-		- "Do I need my own sword?" [!hide_this_option]
-			say player	"If there's a dragon, do I need my own sword?"
-			say worker	"Can you run fast?"
-			say player	"Not really."
-			say worker	"Then yes."
-			set_global hide_this_option true
-		- "I've got to go."
-			say player	"I've got to go."
-			say worker	"Bye!"
+		- "Could it be created in Escoria?" [!loom_conversation_done]
+			say player	"Could Loom be created in Escoria?"
+			say worker	"Yes!"
+		- "Is it a fun game?" [!loom_conversation_done, !fun_game_asked]
+			say player	"Is Loom a fun game?"
+			say worker	"Yes!"
+			set_global fun_game_asked true
+		- "I don't want to talk at all any more." [!loom_conversation_done]
 			turn_to worker worker_face_down
 			stop
+		# This will take you back to the outer set of questions
+		- "I know enough about Loom." [!loom_conversation_done]
+			set_global loom_conversation_done true
 		!
-	- "No, I'm not looking for a job."
-		say player	"No, I'm not looking for a job."
-		say worker 	"Well you know where to find me if you change your mind."
+	- "I'm done."
+		say player	"Bye!"
 		turn_to worker worker_face_down
 		stop
 !


### PR DESCRIPTION
…a particular dialog level; this has the somewhat beneficial side effect of moving up a level in dialog if there is one, although this requires a 'stop' command to be present in at least one of the top-most dialog options.

Fixes https://github.com/godot-escoria/escoria-issues/issues/328