### PR TITLE
fix: disallows dialog blocks that aren't properly indented; however, …

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_compiler.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_compiler.gd
@@ -248,8 +248,18 @@ func _compile(lines: Array, path: String = "") -> Array:
 				if next_line_indent > indent:
 					dialog_option_lines.append(next_line)
 				else:
-					lines.push_front(next_line)
-					break
+					if _dialog_end_regex.search(next_line) or \
+						_dialog_option_regex.search(next_line):
+						lines.push_front(next_line)
+						break
+
+					# There MUST be AT LEAST ONE statement/line for a dialog
+					# option's block that's properly indented
+					escoria.logger.error(
+						self,
+						"Dialog option '%s' has at least one line in its block that is not indented sufficiently." \
+							% line
+					)
 			if dialog_option_lines.size() > 0:
 				escoria.logger.trace(
 					self,


### PR DESCRIPTION
…this also changes how dialog options are parsed and will require substantial testing.

Fixes https://github.com/godot-escoria/escoria-issues/issues/335