### PR TITLE
fix: Fix p_child is null exit on quit

### DIFF
--- a/addons/escoria-core/game/scenes/camera_player/esc_camera.gd
+++ b/addons/escoria-core/game/scenes/camera_player/esc_camera.gd
@@ -24,8 +24,8 @@ func _ready():
 
 
 func _exit_tree():
-	remove_child(_tween)
 	if is_instance_valid(_tween):
+		remove_child(_tween)
 		_tween.queue_free()
 
 


### PR DESCRIPTION
This is to fix the bug where if you open a room (e.g. room 4) and go into room 3, then quit the game by force closing the window, you get the error:
E 0:00:05.946   remove_child: Parameter "p_child" is null.
  <C++ Source>  scene/main/node.cpp:1308 @ remove_child()
  <Stack Trace> esc_camera.gd:27 @ _exit_tree()

Only seems to show up with simplemouse, 9 verb didn't show it.