### PR TITLE
RFC : feat: Automatically run idle animation for characters in scene

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -295,6 +295,18 @@ func _ready():
 			_movable.last_scale = scale
 			_movable.update_terrain()
 
+		# If there is an idle animation defined for this item, it's likely a 
+		# character. Start the idle animation automatically as that's likely
+		# to be what the developer expects.
+		if get_animation_player() and \
+			is_instance_valid(animations) and \
+			animations.idles.size() > 0 and \
+			get_animation_player():
+			var animation_direction = _movable.last_dir if is_movable else 0
+			var animation_player = get_animation_player()
+			animation_player.play(
+				animations.idles[0].animation
+			)
 
 # Mouse exited happens on any item that mouse cursor exited, even those UNDER
 # the top level of overlapping stack.


### PR DESCRIPTION
The idea of this code is that if the ESC item being instantiated has idle animations, play the one facing downwards. At the moment, if you have a character other than the player in the scene, the idle animation is not running and requires adding an anim command to setup or ready. I think the developer would expect idle animations to run by default (which is what I expected) - which is why I wrote the code.

Maybe there is a much cleverer/neater way to do this with the dialogue state machine. As this code is in "_ready()" it gets overwritten by an ESC anim command in ":setup" or ":ready", so developers could stop the behavior if they like on an as-needed basis without the need for a new "should_automatically_run_idle_animation" parameter on the ESCItem.