### PR TITLE
fix: Remove call to stop dialog to correct player mirroring

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -749,7 +749,10 @@ func stop_talking():
 	if is_movable:
 		if animations.speaks[_movable.last_dir].mirrored \
 				and not _movable.is_mirrored:
-			_sprite_node.scale.x *= -1
+			# Allow this function to be called multiple times without setting
+			# the direction incorrectly
+			if _sprite_node.scale.x < 1:
+				_sprite_node.scale.x *= -1
 
 		animation_player.play(
 			animations.idles[_movable.last_dir].animation


### PR DESCRIPTION
Without this line being removed, during a conversation, stop talking gets called by both :
![image](https://user-images.githubusercontent.com/5151242/210140092-64967b8f-2b5e-4654-b308-3d327be3aad6.png)
and
![image](https://user-images.githubusercontent.com/5151242/210140048-2c378aa9-990a-4f6f-b28d-43fbbd7da6a1.png)

The result of this is that this code is called twice
```
		if animations.speaks[_movable.last_dir].mirrored \
				and not _movable.is_mirrored:
			_sprite_node.scale.x *= -1
```
Which, when you have a mirrored talking animation, means that the character gets turned to face the wrong way when they finish talking.