### PR TITLE
move dialog settings to another script to fix exported game issues

### DIFF
--- a/addons/escoria-core/game/scenes/dialogs/state_machine/dialog_say.gd
+++ b/addons/escoria-core/game/scenes/dialogs/state_machine/dialog_say.gd
@@ -39,7 +39,7 @@ func initialize(character: String, type: String, text: String) -> void:
 	_type = type
 	_text = text
 	_stop_talking_animation_on_option = \
-		ESCProjectSettingsManager.get_setting(SimpleDialogPlugin.STOP_TALKING_ANIMATION_ON)
+		ESCProjectSettingsManager.get_setting(ESCSimpleDialogSettingsManager.STOP_TALKING_ANIMATION_ON)
 
 
 func handle_input(_event):
@@ -48,20 +48,20 @@ func handle_input(_event):
 			escoria.inputs_manager.INPUT_NONE and \
 			_dialog_manager != null:
 
-			var left_click_action = ESCProjectSettingsManager.get_setting(SimpleDialogPlugin.LEFT_CLICK_ACTION)
+			var left_click_action = ESCProjectSettingsManager.get_setting(ESCSimpleDialogSettingsManager.LEFT_CLICK_ACTION)
 
 			_handle_left_click_action(left_click_action)
 
 
 func _handle_left_click_action(left_click_action: String) -> void:
 	match left_click_action:
-		SimpleDialogPlugin.LEFT_CLICK_ACTION_SPEED_UP:
+		ESCSimpleDialogSettingsManager.LEFT_CLICK_ACTION_SPEED_UP:
 			if _dialog_manager.is_connected("say_visible", self, "_on_say_visible"):
 				_dialog_manager.disconnect("say_visible", self, "_on_say_visible")
 
 			escoria.logger.trace(self, "Dialog State Machine: 'say' -> 'say_fast'")
 			emit_signal("finished", "say_fast")
-		SimpleDialogPlugin.LEFT_CLICK_ACTION_INSTANT_FINISH:
+		ESCSimpleDialogSettingsManager.LEFT_CLICK_ACTION_INSTANT_FINISH:
 			if _dialog_manager.is_connected("say_visible", self, "_on_say_visible"):
 				_dialog_manager.disconnect("say_visible", self, "_on_say_visible")
 
@@ -129,7 +129,7 @@ func enter():
 				 as ESCSpeechPlayer
 			).set_state(_speech_resource)
 
-			if _stop_talking_animation_on_option == SimpleDialogPlugin.STOP_TALKING_ANIMATION_ON_END_OF_AUDIO:
+			if _stop_talking_animation_on_option == ESCSimpleDialogSettingsManager.STOP_TALKING_ANIMATION_ON_END_OF_AUDIO:
 				(
 					escoria.object_manager.get_object(escoria.object_manager.SPEECH).node\
 					 as ESCSpeechPlayer

--- a/addons/escoria-dialog-simple/esc_dialo_simple_settings.gd
+++ b/addons/escoria-dialog-simple/esc_dialo_simple_settings.gd
@@ -1,0 +1,20 @@
+extends Resource
+class_name ESCSimpleDialogSettingsManager
+
+const SETTINGS_ROOT="escoria/dialog_simple"
+
+const AVATARS_PATH = "%s/avatars_path" % SETTINGS_ROOT
+const TEXT_TIME_PER_LETTER_MS = "%s/text_time_per_letter_ms" % SETTINGS_ROOT
+const TEXT_TIME_PER_LETTER_MS_FAST = "%s/text_time_per_fast_letter_ms" % SETTINGS_ROOT
+const READING_SPEED_IN_WPM = "%s/reading_speed_in_wpm" % SETTINGS_ROOT
+const CLEAR_TEXT_BY_CLICK_ONLY = "%s/clear_text_by_click_only" % SETTINGS_ROOT
+const LEFT_CLICK_ACTION = "%s/left_click_action" % SETTINGS_ROOT
+
+const STOP_TALKING_ANIMATION_ON = "%s/stop_talking_animation_on" % SETTINGS_ROOT
+
+const LEFT_CLICK_ACTION_SPEED_UP = "Speed up"
+const LEFT_CLICK_ACTION_INSTANT_FINISH = "Instant finish"
+const LEFT_CLICK_ACTION_NOTHING = "None"
+
+const STOP_TALKING_ANIMATION_ON_END_OF_TEXT = "End of text"
+const STOP_TALKING_ANIMATION_ON_END_OF_AUDIO = "End of audio"

--- a/addons/escoria-dialog-simple/esc_dialog_simple.gd
+++ b/addons/escoria-dialog-simple/esc_dialog_simple.gd
@@ -1,6 +1,5 @@
 # A simple dialog manager for Escoria
 extends ESCDialogManager
-class_name ESCDialogSimple
 
 
 # The currently running player

--- a/addons/escoria-dialog-simple/esc_dialog_simple_settings.gd
+++ b/addons/escoria-dialog-simple/esc_dialog_simple_settings.gd
@@ -1,7 +1,7 @@
 extends Resource
 class_name ESCSimpleDialogSettingsManager
 
-const SETTINGS_ROOT="escoria/dialog_simple"
+const SETTINGS_ROOT = "escoria/dialog_simple"
 
 const AVATARS_PATH = "%s/avatars_path" % SETTINGS_ROOT
 const TEXT_TIME_PER_LETTER_MS = "%s/text_time_per_letter_ms" % SETTINGS_ROOT

--- a/addons/escoria-dialog-simple/plugin.gd
+++ b/addons/escoria-dialog-simple/plugin.gd
@@ -1,26 +1,8 @@
 # A simple dialog manager for Escoria
 tool
 extends EditorPlugin
-class_name SimpleDialogPlugin
-
 
 const MANAGER_CLASS="res://addons/escoria-dialog-simple/esc_dialog_simple.gd"
-const SETTINGS_ROOT="escoria/dialog_simple"
-
-const AVATARS_PATH = "%s/avatars_path" % SETTINGS_ROOT
-const TEXT_TIME_PER_LETTER_MS = "%s/text_time_per_letter_ms" % SETTINGS_ROOT
-const TEXT_TIME_PER_LETTER_MS_FAST = "%s/text_time_per_fast_letter_ms" % SETTINGS_ROOT
-const READING_SPEED_IN_WPM = "%s/reading_speed_in_wpm" % SETTINGS_ROOT
-const CLEAR_TEXT_BY_CLICK_ONLY = "%s/clear_text_by_click_only" % SETTINGS_ROOT
-const LEFT_CLICK_ACTION = "%s/left_click_action" % SETTINGS_ROOT
-const STOP_TALKING_ANIMATION_ON = "%s/stop_talking_animation_on" % SETTINGS_ROOT
-
-const LEFT_CLICK_ACTION_SPEED_UP = "Speed up"
-const LEFT_CLICK_ACTION_INSTANT_FINISH = "Instant finish"
-const LEFT_CLICK_ACTION_NOTHING = "None"
-
-const STOP_TALKING_ANIMATION_ON_END_OF_TEXT = "End of text"
-const STOP_TALKING_ANIMATION_ON_END_OF_AUDIO = "End of audio"
 
 const READING_SPEED_IN_WPM_DEFAULT_VALUE = 200
 const TEXT_TIME_PER_LETTER_MS_DEFAULT_VALUE = 100
@@ -28,14 +10,14 @@ const TEXT_TIME_PER_LETTER_MS_FAST_DEFAULT_VALUE = 25
 
 
 var left_click_actions: PoolStringArray = [
-	LEFT_CLICK_ACTION_SPEED_UP,
-	LEFT_CLICK_ACTION_INSTANT_FINISH,
-	LEFT_CLICK_ACTION_NOTHING
+	ESCProjectSettingsManager.LEFT_CLICK_ACTION_SPEED_UP,
+	ESCProjectSettingsManager.LEFT_CLICK_ACTION_INSTANT_FINISH,
+	ESCProjectSettingsManager.LEFT_CLICK_ACTION_NOTHING
 ]
 
 var stop_talking_animation_on_options: PoolStringArray = [
-	STOP_TALKING_ANIMATION_ON_END_OF_TEXT,
-	STOP_TALKING_ANIMATION_ON_END_OF_AUDIO
+	ESCProjectSettingsManager.STOP_TALKING_ANIMATION_ON_END_OF_TEXT,
+	ESCProjectSettingsManager.STOP_TALKING_ANIMATION_ON_END_OF_AUDIO
 ]
 
 
@@ -52,31 +34,31 @@ func disable_plugin():
 	)
 
 	ESCProjectSettingsManager.remove_setting(
-		AVATARS_PATH
+		ESCSimpleDialogSettingsManager.AVATARS_PATH
 	)
 
 	ESCProjectSettingsManager.remove_setting(
-		TEXT_TIME_PER_LETTER_MS
+		ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS
 	)
 
 	ESCProjectSettingsManager.remove_setting(
-		TEXT_TIME_PER_LETTER_MS_FAST
+		ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_FAST
 	)
 
 	ESCProjectSettingsManager.remove_setting(
-		CLEAR_TEXT_BY_CLICK_ONLY
+		ESCSimpleDialogSettingsManager.CLEAR_TEXT_BY_CLICK_ONLY
 	)
 
 	ESCProjectSettingsManager.remove_setting(
-		READING_SPEED_IN_WPM
+		ESCSimpleDialogSettingsManager.READING_SPEED_IN_WPM
 	)
 
 	ESCProjectSettingsManager.remove_setting(
-		LEFT_CLICK_ACTION
+		ESCSimpleDialogSettingsManager.LEFT_CLICK_ACTION
 	)
 
 	ESCProjectSettingsManager.remove_setting(
-		STOP_TALKING_ANIMATION_ON
+		ESCSimpleDialogSettingsManager.STOP_TALKING_ANIMATION_ON
 	)
 
 	EscoriaPlugin.deregister_dialog_manager(MANAGER_CLASS)
@@ -96,7 +78,7 @@ func enable_plugin():
 		)
 
 		ESCProjectSettingsManager.register_setting(
-			AVATARS_PATH,
+			ESCSimpleDialogSettingsManager.AVATARS_PATH,
 			"res://game/dialog_avatars",
 			{
 				"type": TYPE_STRING,
@@ -105,7 +87,7 @@ func enable_plugin():
 		)
 
 		ESCProjectSettingsManager.register_setting(
-			TEXT_TIME_PER_LETTER_MS,
+			ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS,
 			TEXT_TIME_PER_LETTER_MS_DEFAULT_VALUE,
 			{
 				"type": TYPE_REAL
@@ -113,7 +95,7 @@ func enable_plugin():
 		)
 
 		ESCProjectSettingsManager.register_setting(
-			TEXT_TIME_PER_LETTER_MS_FAST,
+			ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_FAST,
 			TEXT_TIME_PER_LETTER_MS_FAST_DEFAULT_VALUE,
 			{
 				"type": TYPE_REAL
@@ -121,7 +103,7 @@ func enable_plugin():
 		)
 
 		ESCProjectSettingsManager.register_setting(
-			CLEAR_TEXT_BY_CLICK_ONLY,
+			ESCSimpleDialogSettingsManager.CLEAR_TEXT_BY_CLICK_ONLY,
 			false,
 			{
 				"type": TYPE_BOOL
@@ -129,7 +111,7 @@ func enable_plugin():
 		)
 
 		ESCProjectSettingsManager.register_setting(
-			READING_SPEED_IN_WPM,
+			ESCSimpleDialogSettingsManager.READING_SPEED_IN_WPM,
 			READING_SPEED_IN_WPM_DEFAULT_VALUE,
 			{
 				"type": TYPE_INT
@@ -139,8 +121,8 @@ func enable_plugin():
 		var left_click_actions_string: String = left_click_actions.join(",")
 
 		ESCProjectSettingsManager.register_setting(
-			LEFT_CLICK_ACTION,
-			LEFT_CLICK_ACTION_SPEED_UP,
+			ESCSimpleDialogSettingsManager.LEFT_CLICK_ACTION,
+			ESCProjectSettingsManager.LEFT_CLICK_ACTION_SPEED_UP,
 			{
 				"type": TYPE_STRING,
 				"hint": PROPERTY_HINT_ENUM,
@@ -151,8 +133,8 @@ func enable_plugin():
 		var stop_talking_animation_on_options_string: String = stop_talking_animation_on_options.join(",")
 
 		ESCProjectSettingsManager.register_setting(
-			STOP_TALKING_ANIMATION_ON,
-			STOP_TALKING_ANIMATION_ON_END_OF_AUDIO,
+			ESCSimpleDialogSettingsManager.STOP_TALKING_ANIMATION_ON,
+			ESCProjectSettingsManager.STOP_TALKING_ANIMATION_ON_END_OF_AUDIO,
 			{
 				"type": TYPE_STRING,
 				"hint": PROPERTY_HINT_ENUM,

--- a/addons/escoria-dialog-simple/types/avatar.gd
+++ b/addons/escoria-dialog-simple/types/avatar.gd
@@ -47,7 +47,7 @@ onready var is_paused: bool = true
 # Build up the UI
 func _ready():
 	_text_time_per_character = ProjectSettings.get_setting(
-		SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS
+		ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS
 	)
 
 	if _text_time_per_character < 0:
@@ -55,15 +55,15 @@ func _ready():
 			self,
 			"%s setting must be a non-negative number. Will use default value of %s." %
 				[
-					SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS,
-					SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS_DEFAULT_VALUE
+					ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS,
+					ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_DEFAULT_VALUE
 				]
 		)
 
-		_text_time_per_character = SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS_DEFAULT_VALUE
+		_text_time_per_character = ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_DEFAULT_VALUE
 
 	_fast_text_time_per_character = ProjectSettings.get_setting(
-		SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS_FAST
+		ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_FAST
 	)
 
 	if _fast_text_time_per_character < 0:
@@ -71,15 +71,15 @@ func _ready():
 			self,
 			"%s setting must be a non-negative number. Will use default value of %s." %
 				[
-					SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS_FAST,
-					SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS_FAST_DEFAULT_VALUE
+					ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_FAST,
+					ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_FAST_DEFAULT_VALUE
 				]
 		)
 
-		_fast_text_time_per_character = SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS_FAST_DEFAULT_VALUE
+		_fast_text_time_per_character = ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_FAST_DEFAULT_VALUE
 
 	_reading_speed_in_wpm = ProjectSettings.get_setting(
-		SimpleDialogPlugin.READING_SPEED_IN_WPM
+		ESCSimpleDialogSettingsManager.READING_SPEED_IN_WPM
 	)
 
 	if _reading_speed_in_wpm <= 0:
@@ -87,12 +87,12 @@ func _ready():
 			self,
 			"%s setting must be a positive number. Will use default value of %s." %
 				[
-					SimpleDialogPlugin.READING_SPEED_IN_WPM,
-					SimpleDialogPlugin.READING_SPEED_IN_WPM_DEFAULT_VALUE
+					ESCSimpleDialogSettingsManager.READING_SPEED_IN_WPM,
+					ESCSimpleDialogSettingsManager.READING_SPEED_IN_WPM_DEFAULT_VALUE
 				]
 		)
 
-		_reading_speed_in_wpm = SimpleDialogPlugin.READING_SPEED_IN_WPM_DEFAULT_VALUE
+		_reading_speed_in_wpm = ESCSimpleDialogSettingsManager.READING_SPEED_IN_WPM_DEFAULT_VALUE
 
 	_word_regex.compile("\\S+")
 
@@ -208,7 +208,7 @@ func _get_number_of_words() -> int:
 # Ending the dialog
 func _on_dialog_finished():
 	# Only trigger to clear the text if we aren't limiting the clearing trigger to a click.
-	if not ESCProjectSettingsManager.get_setting(SimpleDialogPlugin.CLEAR_TEXT_BY_CLICK_ONLY):
+	if not ESCProjectSettingsManager.get_setting(ESCSimpleDialogSettingsManager.CLEAR_TEXT_BY_CLICK_ONLY):
 		emit_signal("say_finished")
 		queue_free()
 

--- a/addons/escoria-dialog-simple/types/floating.gd
+++ b/addons/escoria-dialog-simple/types/floating.gd
@@ -46,7 +46,7 @@ onready var is_paused: bool = true
 # Enable bbcode and catch the signal when a tween completed
 func _ready():
 	_text_time_per_character = ProjectSettings.get_setting(
-		SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS
+		ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS
 	)
 
 	if _text_time_per_character < 0:
@@ -54,15 +54,15 @@ func _ready():
 			self,
 			"%s setting must be a non-negative number. Will use default value of %s." %
 				[
-					SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS,
-					SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS_DEFAULT_VALUE
+					ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS,
+					ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_DEFAULT_VALUE
 				]
 		)
 
-		_text_time_per_character = SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS_DEFAULT_VALUE
+		_text_time_per_character = ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_DEFAULT_VALUE
 
 	_fast_text_time_per_character = ProjectSettings.get_setting(
-		SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS_FAST
+		ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_FAST
 	)
 
 	if _fast_text_time_per_character < 0:
@@ -70,15 +70,15 @@ func _ready():
 			self,
 			"%s setting must be a non-negative number. Will use default value of %s." %
 				[
-					SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS_FAST,
-					SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS_FAST_DEFAULT_VALUE
+					ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_FAST,
+					ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_FAST_DEFAULT_VALUE
 				]
 		)
 
-		_fast_text_time_per_character = SimpleDialogPlugin.TEXT_TIME_PER_LETTER_MS_FAST_DEFAULT_VALUE
+		_fast_text_time_per_character = ESCSimpleDialogSettingsManager.TEXT_TIME_PER_LETTER_MS_FAST_DEFAULT_VALUE
 
 	_reading_speed_in_wpm = ProjectSettings.get_setting(
-		SimpleDialogPlugin.READING_SPEED_IN_WPM
+		ESCSimpleDialogSettingsManager.READING_SPEED_IN_WPM
 	)
 
 	if _reading_speed_in_wpm <= 0:
@@ -86,12 +86,12 @@ func _ready():
 			self,
 			"%s setting must be a positive number. Will use default value of %s." %
 				[
-					SimpleDialogPlugin.READING_SPEED_IN_WPM,
-					SimpleDialogPlugin.READING_SPEED_IN_WPM_DEFAULT_VALUE
+					ESCSimpleDialogSettingsManager.READING_SPEED_IN_WPM,
+					ESCSimpleDialogSettingsManager.READING_SPEED_IN_WPM_DEFAULT_VALUE
 				]
 		)
 
-		_reading_speed_in_wpm = SimpleDialogPlugin.READING_SPEED_IN_WPM_DEFAULT_VALUE
+		_reading_speed_in_wpm = ESCSimpleDialogSettingsManager.READING_SPEED_IN_WPM_DEFAULT_VALUE
 
 	_word_regex.compile("\\S+")
 
@@ -227,7 +227,7 @@ func _get_number_of_words() -> int:
 # Ending the dialog
 func _on_dialog_finished():
 	# Only trigger to clear the text if we aren't limiting the clearing trigger to a click.
-	if not ESCProjectSettingsManager.get_setting(SimpleDialogPlugin.CLEAR_TEXT_BY_CLICK_ONLY):
+	if not ESCProjectSettingsManager.get_setting(ESCSimpleDialogSettingsManager.CLEAR_TEXT_BY_CLICK_ONLY):
 		emit_signal("say_finished")
 
 

--- a/project.godot
+++ b/project.godot
@@ -239,11 +239,6 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/escoria-core/game/scenes/dialogs/esc_dialog_player.gd"
 }, {
-"base": "ESCDialogManager",
-"class": "ESCDialogSimple",
-"language": "GDScript",
-"path": "res://addons/escoria-dialog-simple/esc_dialog_simple.gd"
-}, {
 "base": "Resource",
 "class": "ESCDirectionAngle",
 "language": "GDScript",
@@ -429,6 +424,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/escoria-core/game/core-scripts/save_data/esc_settings_manager.gd"
 }, {
+"base": "Resource",
+"class": "ESCSimpleDialogSettingsManager",
+"language": "GDScript",
+"path": "res://addons/escoria-dialog-simple/esc_dialog_simple_settings.gd"
+}, {
 "base": "Control",
 "class": "ESCSoundPlayer",
 "language": "GDScript",
@@ -599,11 +599,6 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/escoria-core/game/core-scripts/esc/commands/show_menu.gd"
 }, {
-"base": "EditorPlugin",
-"class": "SimpleDialogPlugin",
-"language": "GDScript",
-"path": "res://addons/escoria-dialog-simple/plugin.gd"
-}, {
 "base": "SlideCommand",
 "class": "SlideBlockCommand",
 "language": "GDScript",
@@ -731,7 +726,6 @@ _global_script_class_icons={
 "ESCDialogOption": "",
 "ESCDialogOptionsChooser": "",
 "ESCDialogPlayer": "",
-"ESCDialogSimple": "",
 "ESCDirectionAngle": "",
 "ESCEvent": "",
 "ESCEventManager": "",
@@ -769,6 +763,7 @@ _global_script_class_icons={
 "ESCScheduledEvent": "",
 "ESCScript": "",
 "ESCSettingsManager": "",
+"ESCSimpleDialogSettingsManager": "",
 "ESCSoundPlayer": "",
 "ESCSpeechPlayer": "",
 "ESCStatement": "",
@@ -803,7 +798,6 @@ _global_script_class_icons={
 "SetSpeedCommand": "",
 "SetStateCommand": "",
 "ShowMenuCommand": "",
-"SimpleDialogPlugin": "",
 "SlideBlockCommand": "",
 "SlideCommand": "",
 "SpawnCommand": "",


### PR DESCRIPTION
There's a problem when you try to export game and launch it, you'll get a grey screen. In the log there's errors about  `Unknown class: "EditorPlugin"` presumably because editor classes aren't exported. The problem is that `escoria-dialog-simple` plugin exports it's class name to other scripts which get settings via it. So I've moved settings to separate script that extends `Resource` same as `ESCProjectSettingsManager`. It fixes the problem.