### PR TITLE
feat: add fullscreen option in options menu

### DIFF
--- a/addons/escoria-core/game/core-scripts/save_data/esc_savesettings.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_savesettings.gd
@@ -39,7 +39,8 @@ export var speech_volume: float = ProjectSettings.get_setting(
 	"escoria/sound/speech_volume")
 
 # True if game has to be fullscreen
-export var fullscreen: bool = false
+export var fullscreen: bool = ProjectSettings.get_setting(
+	"display/window/size/fullscreen")
 
 # Dictionary containing all user-defined settings.
 export var custom_settings: Dictionary

--- a/addons/escoria-core/game/core-scripts/save_data/esc_settings_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_settings_manager.gd
@@ -61,6 +61,9 @@ func apply_settings() -> void:
 				)
 			)
 		)
+		OS.window_fullscreen = ESCProjectSettingsManager.get_setting(
+			ESCProjectSettingsManager.FULLSCREEN
+		)
 		TranslationServer.set_locale(
 			ESCProjectSettingsManager.get_setting(
 				ESCProjectSettingsManager.TEXT_LANG

--- a/addons/escoria-core/ui_library/menus/options/options.gd
+++ b/addons/escoria-core/ui_library/menus/options/options.gd
@@ -61,6 +61,7 @@ func initialize_options(p_settings):
 	_options.get_node("sound_volume").value = p_settings["sfx_volume"]
 	_options.get_node("music_volume").value = p_settings["music_volume"]
 	_options.get_node("speech_volume").value = p_settings["speech_volume"]
+	_options.get_node("fullscreen").set_pressed_no_signal(p_settings["fullscreen"])
 
 
 # The language was changed
@@ -137,6 +138,22 @@ func _on_speech_volume_value_changed(value: float) -> void:
 		ESCProjectSettingsManager.set_setting(
 			ESCProjectSettingsManager.SPEECH_VOLUME,
 			value
+		)
+		escoria.settings_manager.apply_settings()
+		settings_changed = true
+
+
+# Fullscreen was changed
+#
+# #### Parameters
+# - button_pressed: Fullscreen (true) or windowed (false)
+func _on_fullscreen_toggled(button_pressed: bool) -> void:
+	if ESCProjectSettingsManager.get_setting(
+				ESCProjectSettingsManager.FULLSCREEN
+			) != button_pressed:
+		ESCProjectSettingsManager.set_setting(
+			ESCProjectSettingsManager.FULLSCREEN,
+			button_pressed
 		)
 		escoria.settings_manager.apply_settings()
 		settings_changed = true

--- a/addons/escoria-core/ui_library/menus/options/options.tscn
+++ b/addons/escoria-core/ui_library/menus/options/options.tscn
@@ -131,10 +131,22 @@ size_flags_horizontal = 3
 max_value = 1.0
 step = 0.001
 
+[node name="label6" type="Label" parent="VBoxContainer/MarginContainer/options"]
+margin_top = 160.0
+margin_right = 137.0
+margin_bottom = 154.0
+text = "FULLSCREEN"
+
+[node name="fullscreen" type="CheckBox" parent="VBoxContainer/MarginContainer/options"]
+margin_left = 177.0
+margin_top = 160.0
+margin_right = 457.0
+margin_bottom = 155.0
+
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 margin_top = 539.0
 margin_right = 1280.0
-margin_bottom = 559.0
+margin_bottom = 500
 custom_constants/separation = 20
 alignment = 1
 
@@ -160,5 +172,6 @@ __meta__ = {
 [connection signal="value_changed" from="VBoxContainer/MarginContainer/options/sound_volume" to="." method="_on_sound_volume_changed"]
 [connection signal="value_changed" from="VBoxContainer/MarginContainer/options/music_volume" to="." method="_on_music_volume_changed"]
 [connection signal="value_changed" from="VBoxContainer/MarginContainer/options/speech_volume" to="." method="_on_speech_volume_value_changed"]
+[connection signal="toggled" from="VBoxContainer/MarginContainer/options/fullscreen" to="." method="_on_fullscreen_toggled"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/back" to="." method="_on_back_pressed"]
 [connection signal="pressed" from="VBoxContainer/HBoxContainer/apply" to="." method="_on_apply_pressed"]

--- a/game/translations/main_menu.csv
+++ b/game/translations/main_menu.csv
@@ -11,6 +11,7 @@ GENERAL_VOLUME,General,Général,Allgemein
 MUSIC_VOLUME,Music,Musique,Musik
 SOUND_VOLUME,Sound effects,Effets sonores,Soundeffekte
 SPEECH_VOLUME,Speech,Voix,Sprachausgabe
+FULLSCREEN,Fullscreen,Plein écran,Vollbild
 CANCEL,Cancel,Annuler,Abbrechen
 OK,OK,Ok,Ok
 ENTER_SAVE_NAME,Enter the save name:,Entrez un nom de sauvegarde,Bitte gib einen Namen für das Spiel ein:


### PR DESCRIPTION
I'm unsure if I should have used `set_pressed` instead of `set_pressed_no_signal` in `addons/escoria-core/ui_library/menus/options/options.gd` line 64.