### PR TITLE
fix: removes type as ESCResourceCache checks the type of 'res' and ca…

### DIFF
--- a/addons/escoria-core/game/core-scripts/resources/esc_resource_descriptor.gd
+++ b/addons/escoria-core/game/core-scripts/resources/esc_resource_descriptor.gd
@@ -4,12 +4,12 @@ class_name ESCResourceDescriptor
 
 
 # The resource being described
-var res: Resource
+var res
 
 # Whether the resource is permanent
 var permanent: bool
 
 
-func _init(res_in: Resource, permanent_in: bool) -> void:
+func _init(res_in, permanent_in: bool) -> void:
 	res = res_in
 	permanent = permanent_in


### PR DESCRIPTION
…n expect a non-Resource-derived value, e.g. ResourceInteractiveLoader