### PR TITLE
fix: allows avatar (popup) dialogs to resume after pausing is concludes; also prevents unnecessary input from being registered during pauses

### DIFF
--- a/addons/escoria-core/game/escoria.tscn
+++ b/addons/escoria-core/game/escoria.tscn
@@ -4,7 +4,6 @@
 [ext_resource path="res://addons/escoria-core/game/escoria.gd" type="Script" id=3]
 
 [node name="escoria_scene" type="Node"]
-pause_mode = 2
 script = ExtResource( 3 )
 
 [node name="main" parent="." instance=ExtResource( 2 )]

--- a/addons/escoria-dialog-simple/types/avatar.gd
+++ b/addons/escoria-dialog-simple/types/avatar.gd
@@ -223,6 +223,11 @@ func _on_paused():
 # Handler managing resume notification from Escoria
 func _on_resumed():
 	if not tween.is_active():
+		# We can't rely on "show()" to make an invisible popup reappear, as per the docs for
+		# CanvasItem. Instead, we need to use one of the popup_* methods.
+		if is_inside_tree():
+			popup_centered()
+
 		is_paused = false
 		tween.resume_all()
 


### PR DESCRIPTION
Fixes https://github.com/godot-escoria/escoria-issues/issues/356
Fixes https://github.com/godot-escoria/escoria-issues/issues/352