### PR TITLE
Fanout fix

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -15,14 +15,14 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v2
               with:
-                token: ${{ secrets.DEPLOYMENT_TOKEN }}
+                token: ${{ secrets.ESCORIA_DEPLOYMENT_TOKEN }}
                 repository: godot-escoria/escoria-demo-game
                 ref: "develop"
                 path: game
             - name: "Checkout docs repo"
               uses: actions/checkout@v2
               with:
-                token: ${{ secrets.DEPLOYMENT_TOKEN }}
+                token: ${{ secrets.ESCORIA_DEPLOYMENT_TOKEN }}
                 repository: godot-escoria/escoria-docs
                 ref: "devel"
                 fetch-depth: 0

--- a/.github/workflows/fanout.yml
+++ b/.github/workflows/fanout.yml
@@ -44,7 +44,7 @@ jobs:
           repository: "godot-escoria/escoria-demo-game"
           ref: "develop"
           path: "demo-game"
-          token: "${{ secrets.DEPLOYMENT_TOKEN }}"
+          token: "${{ secrets.ESCORIA_DEPLOYMENT_TOKEN }}"
           fetch-depth: 0
       - name: "Filtering out ${{ env.DIR }}"
         run: |
@@ -61,7 +61,7 @@ jobs:
           repository: "${{ env.REPO }}"
           ref: "develop"
           path: "target"
-          token: "${{ secrets.DEPLOYMENT_TOKEN }}"
+          token: "${{ secrets.ESCORIA_DEPLOYMENT_TOKEN }}"
           fetch-depth: 0
       - name: "Apply changes"
         run: |

--- a/.github/workflows/fanout.yml
+++ b/.github/workflows/fanout.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "main"
       - "develop"
+      - "fanout-fix"
 
 concurrency: fanout-${{ github.ref }}
 
@@ -38,7 +39,7 @@ jobs:
               sudo apt-get install git -y
           fi
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           repository: "godot-escoria/escoria-demo-game"
           ref: "develop"
@@ -55,7 +56,7 @@ jobs:
           git clean -fd
           git status
       - name: "Checkout"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
         with:
           repository: "${{ env.REPO }}"
           ref: "develop"

--- a/.github/workflows/fanout.yml
+++ b/.github/workflows/fanout.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "main"
       - "develop"
-      - "fanout-fix"
 
 concurrency: fanout-${{ github.ref }}
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.DEPLOYMENT_TOKEN }}
+          token: ${{ secrets.ESCORIA_DEPLOYMENT_TOKEN }}
       - name: Remove trailing whitespace
         run: |
           OUTPUT=$(find . -name "*.gd" -type f | xargs sed -i 's/[[:space:]]$//')
@@ -29,7 +29,7 @@ jobs:
         id: calculate_version
         uses: mathieudutour/github-tag-action@v5.6
         with:
-          github_token: ${{ secrets.DEPLOYMENT_TOKEN }}
+          github_token: ${{ secrets.ESCORIA_DEPLOYMENT_TOKEN }}
           dry_run: true
           pre_release_branches: "develop"
           append_to_pre_release_tag: "alpha"
@@ -58,12 +58,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          token: ${{ secrets.DEPLOYMENT_TOKEN }}
+          token: ${{ secrets.ESCORIA_DEPLOYMENT_TOKEN }}
       - name: Create version
         id: create_version
         uses: mathieudutour/github-tag-action@v5.6
         with:
-          github_token: ${{ secrets.DEPLOYMENT_TOKEN }}
+          github_token: ${{ secrets.ESCORIA_DEPLOYMENT_TOKEN }}
           dry_run: true
           pre_release_branches: "develop"
           append_to_pre_release_tag: "alpha"
@@ -72,7 +72,7 @@ jobs:
       - name: Create a GitHub release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.DEPLOYMENT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ESCORIA_DEPLOYMENT_TOKEN }}
         with:
           tag_name: ${{ steps.create_version.outputs.new_tag }}
           release_name: ${{ steps.create_version.outputs.new_tag }}


### PR DESCRIPTION
The actual "fix" involved resetting those fanout repos that used 'core' as there was a commit from mid-2022 that seemed not to exist in the demo game repo.

Also updates the deployment token used in other GH Actions jobs.