### PR TITLE
Make ESCBackground node be the 1st child of ESCRoom on run

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_room.gd
+++ b/addons/escoria-core/game/core-scripts/esc_room.gd
@@ -76,6 +76,7 @@ func _ready():
 	for child in get_children():
 		if child is ESCBackground:
 			found_escbackground = true
+			move_child(child, 0)
 	if not found_escbackground:
 		var esc_bg = ESCBackground.new()
 		esc_bg.name = "background"


### PR DESCRIPTION
Fixes the issue with using buttons in room10 (click on verb then on item, not the default action)