### PR TITLE
fix: fixes incorrect handler signature; also checks for null since it…

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/slide.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/slide.gd
@@ -117,5 +117,6 @@ func interrupt():
 		tween.stop_all()
 
 
-func _on_tween_completed(tween: Tween):
-	tween.queue_free()
+func _on_tween_completed(tween: Tween, _key: NodePath):
+	if tween:
+		tween.queue_free()


### PR DESCRIPTION
… appears that sometimes the tween parameter is null when the handler is called