### PR TITLE
Fix crash in room19

### DIFF
--- a/addons/escoria-core/game/esc_inputs_manager.gd
+++ b/addons/escoria-core/game/esc_inputs_manager.gd
@@ -676,9 +676,10 @@ class HoverStack:
 	# #### Parameters
 	# - item: the item to remove from the hover stack
 	func erase_item(item):
-		hover_stack.erase(item)
-		_sort()
-		emit_signal("hover_stack_changed")
+		if hover_stack.has(item):
+			hover_stack.erase(item)
+			_sort()
+			emit_signal("hover_stack_changed")
 
 
 	# Clear the stack of hovered items


### PR DESCRIPTION
Fixed by not emitting a signal stating hover_stack change when the item was not in the hover_stack