### PR TITLE
fix: addresses issue where using ColorN for dialog_color is buggy

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -129,7 +129,7 @@ export(Texture) var inventory_texture: Texture = null \
 		setget ,_get_inventory_texture
 
 # Color used for dialogs
-export(Color) var dialog_color = ColorN("white")
+export(Color) var dialog_color = Color(1,1,1,1)
 
 # If true, terrain scaling will not be applied and
 # node will remain at the scale set in the scene.


### PR DESCRIPTION
If ColorN is used, for some reason, the dialog color is reset to white (ignoring any changes made by the developer) when the game is started. The equivalent "color" command doesn't show this bug.