### PR TITLE
feat: Item components

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_inventory_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_inventory_item.gd
@@ -12,4 +12,6 @@ var texture: Texture = null
 func _init(p_item: ESCItem) -> void:
 	global_id = p_item.global_id
 	texture = p_item._get_inventory_texture()
+	# Explicit component registration, for item that are not in a room.
+	p_item._register_item_components()
 

--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -153,6 +153,8 @@ export(NodePath) var camera_node
 # Avoid name collision using proper key names.
 export(Dictionary) var custom_data = {}
 
+# Item component reference holder
+var components: Dictionary = {}
 
 # ESCAnimationsResource (for walking, idling...)
 var animations: ESCAnimationResource setget set_animations
@@ -838,6 +840,9 @@ func _detect_children() -> void:
 	for c in get_children():
 		if c is CollisionShape2D or c is CollisionPolygon2D:
 			collision = c
+	# Register item components
+	_register_item_components()
+
 
 
 # Upate the terrain when an event finished
@@ -926,3 +931,30 @@ func _get_identifier_as_key_value() -> String:
 # Returns true if the player is currently moving, false otherwise
 func is_moving() -> bool:
 	return _movable.task != ESCMovable.MovableTask.NONE if is_movable else false
+
+# Return true/false if component reference exists.
+func has_component(key: String)->bool:
+	return components.has(key)
+
+# Returns component or null.	
+func get_component(key: String):
+	if(has_component(key)):
+		return components[key]
+	return null
+
+
+# Detect the child item components and set respective references
+func _register_item_components():
+	# Autoload components on runtime
+	_autoload_item_components()
+	for child in get_children():
+		if(child is ESCItemComponent):
+			child = child as ESCItemComponent
+			# Adds reference for later use.
+			components[child.get_component_type()] = child
+			# Calls the component registration with custom_data as reference.
+			child.register(custom_data)
+
+# Extendable function for addons. Allows to define custom components with code.
+func _autoload_item_components():
+	pass

--- a/addons/escoria-core/game/core-scripts/item_components/esc_item_component.gd
+++ b/addons/escoria-core/game/core-scripts/item_components/esc_item_component.gd
@@ -1,0 +1,19 @@
+# Base class for item components.
+# Item components allow to extend base ESCItem without changing the core class.
+extends Node
+class_name ESCItemComponent, "res://addons/escoria-core/design/esc_item.svg"
+
+# Custom data from the parent.
+var _custom_data: Dictionary 
+
+# Returns the global_id from the parent.
+func get_global_id():
+    return self.get_parent().global_id
+
+# Returns component type string. Requires an unique type for each item component.
+func get_component_type():
+    pass
+
+# Custom registration. Optional
+func register(custom_data: Dictionary):
+    pass

--- a/project.godot
+++ b/project.godot
@@ -279,6 +279,11 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://addons/escoria-core/game/core-scripts/esc_item.gd"
 }, {
+"base": "Node",
+"class": "ESCItemComponent",
+"language": "GDScript",
+"path": "res://addons/escoria-core/game/core-scripts/item_components/esc_item_component.gd"
+}, {
 "base": "Position2D",
 "class": "ESCLocation",
 "language": "GDScript",
@@ -704,6 +709,7 @@ _global_script_class_icons={
 "ESCInventoryItem": "",
 "ESCInventoryManager": "",
 "ESCItem": "res://addons/escoria-core/design/esc_item.svg",
+"ESCItemComponent": "res://addons/escoria-core/design/esc_item.svg",
 "ESCLocation": "res://addons/escoria-core/design/esc_location.svg",
 "ESCMain": "",
 "ESCMigration": "",


### PR DESCRIPTION
# Feature
Basic implementation that allows extending ESCItem without touching the core.
We pass custom_data to the components by reference so components can have persistend data.

For now there is a super basic autoload for components... but i think, in the future,  it should be done with an item_component_manager to check for name collisions and automatic initialization for the components without extending ESCItem.

With this implementation we are composing all our ESCItem customizations.

# How to test
- Open the demo game. Everything should work as always without errors in the log.