### PR TITLE
fix: Allow ':' in dialog options default text

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/types/esc_dialog_option.gd
+++ b/addons/escoria-core/game/core-scripts/esc/types/esc_dialog_option.gd
@@ -54,13 +54,14 @@ func load_string(option_string: String):
 func get_translated_option():
 	# Check if text has a key
 	if ":" in option:
-		var splitted_text = option.split(":")
+		var splitted_text = option.split(":", true, 1)
 		var key = splitted_text[0]
 		var translated_text = tr(key)
 
-		# If no translation is found use default text
 		if key != translated_text:
-			return tr(key)
+			return translated_text
+
+		# If no translation is found return default text
 		if splitted_text.size() > 1:
 			return splitted_text[1]
 

--- a/game/rooms/room06/esc/worker.esc
+++ b/game/rooms/room06/esc/worker.esc
@@ -52,7 +52,7 @@ turn_to worker player
 		- "I know enough about Loom." [!loom_conversation_done]
 			set_global loom_conversation_done true
 		!
-	- ROOM6_dialog_bye:"I'm done."
+	- ROOM6_dialog_bye:"I'm done: Bye!"
 		say player	"Bye!"
 		turn_to worker worker_face_down
 		stop


### PR DESCRIPTION
Having a dialog option like `ROOM6_dialog_bye:"I'm done: Bye!"` is shown as `I'm done`. This PR fixes that.