### PR TITLE
fixed dialogue appearing only on top of the screen

### DIFF
--- a/addons/escoria-wizard/CharacterCreator.gd
+++ b/addons/escoria-wizard/CharacterCreator.gd
@@ -1338,8 +1338,8 @@ func export_player(scene_name) -> void:
 	yield(get_tree(), "idle_frame")
 
 	# Add Dialog Position to the ESCPlayer
-	var dialog_position = ESCLocation.new()
-	dialog_position.name = "dialog_position"
+	var dialog_position = ESCDialogLocation.new()
+	dialog_position.name = "ESCDialogLocation"
 	dialog_position.position.y = -(export_largest_sprite.y * 1.2)
 	new_character.add_child(dialog_position)
 


### PR DESCRIPTION
When creating a new character using the Escoria Wizard, the floating dialogue appears only on the top of the screen, regardless of the position of the Dialogue Location set in the character scene.

The Wizard creates a instance of a ESCLocation class for the dialog_position:
![image](https://github.com/godot-escoria/escoria-demo-game/assets/83772261/fc750031-bb09-4ef5-81c1-77428e216658)

Whereas the floating dialog requires an ESCDialogLocation class (addons/escoria-dialog-simple/types/floating.gd):
![image](https://github.com/godot-escoria/escoria-demo-game/assets/83772261/4063a96a-c225-4496-bf56-8bf2e5463c73)
