### PR TITLE
Disable GH action api doc

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -9,6 +9,7 @@ concurrency: api-${{ github.ref }}
 
 jobs:
     apidoc:
+        if: ${{ false }} # <- This make sure the workflow is skipped without any alert
         name: Update API docs
         runs-on: ubuntu-latest
         steps:


### PR DESCRIPTION
Since gdquest's tool is no longer compatible with Godot 4.x