### PR TITLE
[bug] set ESCSaveSettings.fullscreen based on display/window/size/mode

### DIFF
--- a/addons/escoria-core/game/core-scripts/save_data/esc_settings_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_settings_manager.gd
@@ -155,8 +155,8 @@ func get_settings() -> ESCSaveSettings:
 		ESCProjectSettingsManager.SPEECH_VOLUME
 	)
 	settings.fullscreen = ESCProjectSettingsManager.get_setting(
-		ESCProjectSettingsManager.FULLSCREEN
-	)
+		ESCProjectSettingsManager.WINDOW_MODE
+	) in [DisplayServer.WINDOW_MODE_FULLSCREEN, DisplayServer.WINDOW_MODE_EXCLUSIVE_FULLSCREEN]
 	settings.custom_settings = custom_settings
 
 	return settings

--- a/addons/escoria-core/game/esc_project_settings_manager.gd
+++ b/addons/escoria-core/game/esc_project_settings_manager.gd
@@ -71,6 +71,7 @@ const SKIP_CACHE_MOBILE = _ESCORIA_SETTINGS_ROOT + "/" + _PLATFORM_ROOT + "/" + 
 const DISPLAY = "display"
 const WINDOW = "window"
 const SIZE = "size"
+const WINDOW_MODE = DISPLAY + "/" + WINDOW + "/" + SIZE + "/" + "mode"
 const FULLSCREEN = DISPLAY + "/" + WINDOW + "/" + SIZE + "/" + "fullscreen"
 
 

--- a/addons/escoria-core/plugin.gd
+++ b/addons/escoria-core/plugin.gd
@@ -237,6 +237,14 @@ func set_escoria_main_settings():
 		}
 	)
 
+	register_setting(
+		ESCProjectSettingsManager.WINDOW_MODE,
+		false,
+		{
+			"type": TYPE_BOOL,
+		}
+	)
+
 
 # Prepare the settings in the Escoria debug category
 func set_escoria_debug_settings():


### PR DESCRIPTION
I just did a clean install of Godot 4.3 followed by a fresh clone of https://github.com/godot-escoria/escoria-demo-game and starting the demo game crashed at startup because the setting `display/window/size/fullscreen` defined here was not set:

https://github.com/godot-escoria/escoria-demo-game/blob/eb9f5cb0edda010df879541810eb7802bd68eccf/addons/escoria-core/game/esc_project_settings_manager.gd#L74

Though when I looked in **Project Settings**, a similar setting (`display/window/size/mode`) is available by default:

![image](https://github.com/user-attachments/assets/919a4b36-8a45-4a68-a02b-8d33f9a31669)

This PR redefines how `ESCSaveSettings.fullscreen` is initialized to be defined in terms of the existing setting (`true` if it is either "fullscreen" or "exclusive fullscreen") to avoid the crash.

It also adds a `register_setting()` call to `addons/escoria-core/plugin.gd` for `ESCProjectSettingsManager.WINDOW_MODE`.