### PR TITLE
fix: addresses Godot 4-specific issues related to popups and the "has" method

### DIFF
--- a/addons/escoria-dialog-simple/esc_dialog_simple.gd
+++ b/addons/escoria-dialog-simple/esc_dialog_simple.gd
@@ -89,7 +89,7 @@ func say(dialog_player: Node, global_id: String, text: String, type: String, key
 		# we want to remove the old one (if it exists) and then initialize and add the new dialog
 		# box type to the dialog player
 		if type != _preserved_type_player_type:
-			if _dialog_player.get_children().has(_type_player):
+			if is_instance_valid(_type_player) and _dialog_player.get_children().has(_type_player):
 				_dialog_player.remove_child(_type_player)
 
 			_init_type_player(type)

--- a/addons/escoria-dialog-simple/types/avatar.gd
+++ b/addons/escoria-dialog-simple/types/avatar.gd
@@ -1,5 +1,5 @@
 # A dialog GUI showing a dialog box and character portraits
-extends Popup
+extends Window
 
 
 # Signal emitted when text has been said
@@ -41,7 +41,6 @@ var _current_line: String
 
 # Whether the dialog manager is paused
 @onready var is_paused: bool = true
-
 
 # Build up the UI
 func _ready():
@@ -137,6 +136,7 @@ func say(character: String, line: String):
 	_current_line = line
 
 	_is_speeding_up = false
+
 	popup_centered()
 	set_current_character(character)
 

--- a/addons/escoria-dialog-simple/types/avatar.tscn
+++ b/addons/escoria-dialog-simple/types/avatar.tscn
@@ -2,9 +2,13 @@
 
 [ext_resource type="Script" uid="uid://cfkvypxfuu2mt" path="res://addons/escoria-dialog-simple/types/avatar.gd" id="1"]
 
-[node name="dialog_box" type="Popup"]
+[node name="dialog_box" type="Window"]
+position = Vector2i(0, 36)
 size = Vector2i(510, 180)
-visible = true
+visible = false
+unresizable = true
+borderless = true
+popup_window = true
 script = ExtResource("1")
 
 [node name="Timer" type="Timer" parent="."]
@@ -13,6 +17,9 @@ script = ExtResource("1")
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+offset_right = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="Panel"]
 layout_mode = 0


### PR DESCRIPTION
In Godot 4, popups do not behave the same way as in Godot 3, and so require the use of the base `Window` class but customized. It's also worth noting that `Window` is now derived from `Viewport` and not `Control`.

Also, the "has" method doesn't like working with invalid instances.