### PR TITLE
Godot4/fix savegame menu

### DIFF
--- a/addons/escoria-core/ui_library/menus/load_save/load/load_game.tscn
+++ b/addons/escoria-core/ui_library/menus/load_save/load/load_game.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=3 format=3 uid="uid://j3wkbyhedkpr"]
 
-[ext_resource type="PackedScene" path="res://addons/escoria-core/ui_library/menus/load_save/load_save_slot/load_save_slot.tscn" id="2"]
+[ext_resource type="PackedScene" uid="uid://ciysuxd81qucn" path="res://addons/escoria-core/ui_library/menus/load_save/load_save_slot/load_save_slot.tscn" id="2"]
 [ext_resource type="Script" uid="uid://yfabboc406rf" path="res://addons/escoria-core/ui_library/menus/load_save/load/load_game.gd" id="3"]
 
 [node name="load_game" type="Control"]

--- a/addons/escoria-core/ui_library/menus/load_save/save/save_game.tscn
+++ b/addons/escoria-core/ui_library/menus/load_save/save/save_game.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="PackedScene" uid="uid://ciysuxd81qucn" path="res://addons/escoria-core/ui_library/menus/load_save/load_save_slot/load_save_slot.tscn" id="1"]
 [ext_resource type="Script" uid="uid://crpi3w8bdekpc" path="res://addons/escoria-core/ui_library/menus/load_save/save/save_game.gd" id="2"]
-[ext_resource type="PackedScene" path="res://addons/escoria-core/ui_library/menus/load_save/save/save_name_popup.tscn" id="4"]
+[ext_resource type="PackedScene" uid="uid://coiqm0xcq8f8o" path="res://addons/escoria-core/ui_library/menus/load_save/save/save_name_popup.tscn" id="4"]
 [ext_resource type="PackedScene" uid="uid://c4ldxsprk70gi" path="res://addons/escoria-core/ui_library/menus/load_save/save/overwrite_confirm_popup.tscn" id="5"]
 
 [node name="save_game" type="Control"]
@@ -10,19 +10,24 @@ layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 script = ExtResource("2")
 slot_ui_scene = ExtResource("1")
 
-[node name="Panel" type="Panel" parent="."]
+[node name="Panel" type="ColorRect" parent="."]
 layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 offset_top = -1.0
 offset_bottom = -1.0
+color = Color(0.270588, 0.270588, 0.270588, 1)
 
 [node name="save_name_popup" parent="." instance=ExtResource("4")]
+size = Vector2i(209, 185)
 
 [node name="overwrite_confirm_popup" parent="." instance=ExtResource("5")]
+size = Vector2i(231, 134)
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 0

--- a/addons/escoria-core/ui_library/menus/pause_menu/pause_menu.tscn
+++ b/addons/escoria-core/ui_library/menus/pause_menu/pause_menu.tscn
@@ -24,9 +24,7 @@ color = Color(0.270588, 0.270588, 0.270588, 1)
 
 [node name="save_game" parent="." instance=ExtResource("4")]
 visible = false
-anchors_preset = 0
-anchor_right = 0.0
-anchor_bottom = 0.0
+layout_mode = 1
 theme = ExtResource("6")
 
 [node name="load_game" parent="." instance=ExtResource("5")]

--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -404,9 +404,11 @@ func unpause_game():
 		escoria.object_manager.get_object(ESCObjectManager.SPEECH).node.resume()
 		escoria.main.current_scene.game.show_ui()
 		escoria.main.current_scene.show()
+		escoria.set_game_paused(false)
 
 func pause_game():
 	show_ui()
+	
 	if not get_node(pause_menu).visible:
 		get_node(main_menu).reset()
 		get_node(pause_menu).reset()
@@ -417,6 +419,7 @@ func pause_game():
 		escoria.object_manager.get_object(ESCObjectManager.SPEECH).node.pause()
 		escoria.main.current_scene.game.hide_ui()
 		escoria.main.current_scene.hide()
+		escoria.set_game_paused(true)
 
 
 func apply_custom_settings(custom_settings: Dictionary):


### PR DESCRIPTION
Save menu was broken in pause menu. Now centered and showing as expected.
Also, simple mouse's pause menu now does pause the game as it should.