### PR TITLE
feat: Depency injection proposal

### DIFF
--- a/addons/escoria-core/game/esc_autoload.gd
+++ b/addons/escoria-core/game/esc_autoload.gd
@@ -56,6 +56,9 @@ var object_manager = ESCObjectManager.new()
 # ESC Room Manager
 var room_manager = ESCRoomManager.new()
 
+# ESC Dependency Injector
+var di = ESCDependencyInjector.new()
+
 # Terrain of the current room
 var room_terrain
 

--- a/addons/escoria-core/game/esc_dependency_injector.gd
+++ b/addons/escoria-core/game/esc_dependency_injector.gd
@@ -1,0 +1,16 @@
+# Escoria dependency injector
+# Holds class creation methods for replacing non singelton Escoria core classes.
+# If you need to replace an Escoria core class follow the next steps:
+# 1. Create a class in your project that extends ESCDepencyInjector: `extends ESCDependencyInjector`
+# 2. Override the methods that create the classes that you want to replace
+# 3. In your game initialitation replace `escoria.di` variable with your class: `escoria.di = MyDependencyInjector.new()`
+#
+# For more details see: https://docs.godotengine.org/en/stable/tutorials/best_practices/scene_organization.html
+#
+# @ESC
+class_name ESCDependencyInjector
+
+func esc_inventory_item(p_item: ESCItem):
+	return ESCInventoryItem.new(p_item)
+
+# ToDo: Add methods for relevant classes.

--- a/addons/escoria-core/game/esc_dependency_injector.gd
+++ b/addons/escoria-core/game/esc_dependency_injector.gd
@@ -1,13 +1,13 @@
-# Escoria dependency injector
-# Holds class creation methods for replacing non singelton Escoria core classes.
-# If you need to replace an Escoria core class follow the next steps:
-# 1. Create a class in your project that extends ESCDepencyInjector: `extends ESCDependencyInjector`
-# 2. Override the methods that create the classes that you want to replace
-# 3. In your game initialitation replace `escoria.di` variable with your class: `escoria.di = MyDependencyInjector.new()`
-#
-# For more details see: https://docs.godotengine.org/en/stable/tutorials/best_practices/scene_organization.html
-#
-# @ESC
+## Escoria dependency injector
+##
+## Holds factory methods for replacing non-singleton Escoria core classes. 
+## If you wish to replace any Escoria core classes with your own derived classes, follow these steps:[br]
+## 1. Create a class in your project that extends `ESCDependencyInjector`: `extends ESCDependencyInjector`[br]
+## 2. Override the methods that create the classes that you want to replace.[br]
+## 3. In your game initialization, replace the `escoria.di` instance variable with your new dependency injector: 
+## `escoria.di = MyDependencyInjector.new()`[br]
+##[br]
+## For more details see: https://docs.godotengine.org/en/stable/tutorials/best_practices/scene_organization.html
 class_name ESCDependencyInjector
 
 func esc_inventory_item(p_item: ESCItem):

--- a/addons/escoria-core/game/esc_dependency_injector.gd.uid
+++ b/addons/escoria-core/game/esc_dependency_injector.gd.uid
@@ -1,0 +1,1 @@
+uid://dvq6xda38jklr

--- a/addons/escoria-core/game/scenes/inventory/inventory_ui.gd
+++ b/addons/escoria-core/game/scenes/inventory/inventory_ui.gd
@@ -70,7 +70,7 @@ func add_new_item_by_id(item_id: String) -> void:
 						]
 				)
 
-		var inventory_item = ESCInventoryItem.new(
+		var inventory_item = escoria.di.esc_inventory_item(
 			escoria.object_manager.get_object(item_id).node
 		)
 		var inventory_item_button = get_node(


### PR DESCRIPTION
### Simple Depency Injection (DI) proposal
Our problem:
- We need to override `ESCInventoryItem` class to fit our UI.
- The script `addons/escoria-core/game/scenes/inventory/inventory_ui.gd:L73` creates an instance of the `ESCInventoryItem` class. This makes changing `ESCInventoryItem` require replacing the `ESCInventory` core script.

Our proposal:
- Add simple dependency injection to change `ESCInventoryItem` without touching `ESCInventory`

ToDo:
- Decide which other classes to inject via DI. Singleton classes are not needed to be included because they are called from the autload is simple to override.  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a flexible dependency injection framework to enhance overall game customization.
- **Refactor**
  - Updated the inventory item creation process to leverage the new system, offering a more modular and adaptable approach for item instantiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->