### PR TITLE
fix: avoid crashing when loading savegame with items in inventory

### DIFF
--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -455,7 +455,7 @@ func _load_savegame_inventory(savegame_inventory: Array):
 	escoria.logger.info(self, "Loading inventory")
 
 	for g in savegame_inventory:
-		_add_inventory.run([g, savegame_inventory[g]])
+		_add_inventory.run([g])
 
 	escoria.logger.info(self, "Finished loading inventory")
 


### PR DESCRIPTION
fix(savegames): avoid crashing when loading savegame with items in inventory