### PR TITLE
fix: click doesn't reset walk animation anymore.

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -87,7 +87,7 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 		match action:
 			ACTION.BACKGROUND_CLICK:
 				if can_interrupt:
-					escoria.event_manager.interrupt()
+					escoria.event_manager.interrupt([], false)
 
 				var walk_fast = false
 				if params.size() > 2:
@@ -128,7 +128,7 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 					)
 
 					if can_interrupt:
-						escoria.event_manager.interrupt()
+						escoria.event_manager.interrupt([], false)
 
 					var item = escoria.object_manager.get_object(params[0])
 
@@ -142,7 +142,7 @@ func do(action: int, params: Array = [], can_interrupt: bool = false) -> void:
 					)
 
 					if can_interrupt:
-						escoria.event_manager.interrupt()
+						escoria.event_manager.interrupt([], false)
 
 					var item = escoria.object_manager.get_object(params[0])
 

--- a/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
@@ -311,10 +311,11 @@ func queue_background_event(channel_name: String, event: ESCGrammarStmts.Event) 
 #
 # #### Parameters
 # - exceptions: an optional list of events which should be left running or queued
-func interrupt(exceptions: PackedStringArray = []) -> void:
+func interrupt(exceptions: PackedStringArray = [], stop_walking = true) -> void:
 	if escoria.main.current_scene != null \
 			and escoria.main.current_scene.player != null \
-			and escoria.main.current_scene.player.is_moving():
+			and escoria.main.current_scene.player.is_moving() \
+			and stop_walking:
 		escoria.main.current_scene.player.stop_walking_now()
 
 	for channel_name in _running_events.keys():

--- a/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
@@ -314,10 +314,10 @@ func queue_background_event(channel_name: String, event: ESCGrammarStmts.Event) 
 # - stop_walking: boolean value (default true) determining whether the player 
 # (if any) has to be interrupted walking or not.
 func interrupt(exceptions: PackedStringArray = [], stop_walking = true) -> void:
-	if escoria.main.current_scene != null \
+	if stop_walking \
+			and escoria.main.current_scene != null \
 			and escoria.main.current_scene.player != null \
-			and escoria.main.current_scene.player.is_moving() \
-			and stop_walking:
+			and escoria.main.current_scene.player.is_moving():
 		escoria.main.current_scene.player.stop_walking_now()
 
 	for channel_name in _running_events.keys():

--- a/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_event_manager.gd
@@ -311,6 +311,8 @@ func queue_background_event(channel_name: String, event: ESCGrammarStmts.Event) 
 #
 # #### Parameters
 # - exceptions: an optional list of events which should be left running or queued
+# - stop_walking: boolean value (default true) determining whether the player 
+# (if any) has to be interrupted walking or not.
 func interrupt(exceptions: PackedStringArray = [], stop_walking = true) -> void:
 	if escoria.main.current_scene != null \
 			and escoria.main.current_scene.player != null \


### PR DESCRIPTION
Now if you left click continuously while player is walking, the walk animation won't reset anymore (which was resulting in player moving but animation was frozen).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved how gameplay interruptions work during interactions. Player actions now result in a more predictable halt of in-game movement—ensuring that when you click on background areas or items, your character stops as expected for a smoother, more responsive experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->