### PR TITLE
fix: tooltip position

### DIFF
--- a/addons/escoria-core/game/esc_autoload.gd
+++ b/addons/escoria-core/game/esc_autoload.gd
@@ -126,7 +126,9 @@ var creating_new_game: bool = false
 var temp: int = 0
 
 # The game resolution
-@onready var game_size = get_viewport().size
+@onready var game_size = Vector2(
+	ProjectSettings.get_setting("display/window/size/viewport_width"),
+	ProjectSettings.get_setting("display/window/size/viewport_height"))
 
 # The current state of the game
 @onready var current_state = GAME_STATE.DEFAULT


### PR DESCRIPTION
Keep the position of tooltips consistent, even if the viewport is resized, by setting the game size to the design size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated how the game size is initialized to use fixed project settings instead of dynamically retrieving the viewport size. This ensures consistent sizing based on configured values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->