### PR TITLE
fix: resets the interpreter after each 'new game' call in order to properly reset globals

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_environment.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_environment.gd
@@ -12,6 +12,14 @@ func init(enclosing) -> void:
 	_enclosing = enclosing
 
 
+func cleanup() -> void:
+	if is_instance_valid(_enclosing):
+		_enclosing.cleanup()
+		_enclosing = null
+
+	_values.clear()
+
+
 func is_valid_key(name: ESCToken):
 	if _values.has(name.get_lexeme()):
 		return true

--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_interpreter.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_interpreter.gd
@@ -47,6 +47,20 @@ func _init(callables: Array, globals: Dictionary):
 		escoria.globals_manager.global_changed.connect(_on_global_changed)
 
 
+func cleanup() -> void:
+	if is_instance_valid(_globals):
+		_globals.cleanup()
+		_globals = null
+
+	if is_instance_valid(_environment):
+		_environment.cleanup()
+		_environment = null
+
+	_locals.clear()
+
+	_current_event = null
+
+
 func get_global_values() -> Dictionary:
 	return _globals.get_values()
 

--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_interpreter.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_interpreter.gd
@@ -58,7 +58,8 @@ func cleanup() -> void:
 
 	_locals.clear()
 
-	_current_event = null
+	if not Engine.is_editor_hint():
+		escoria.globals_manager.global_changed.disconnect(_on_global_changed)
 
 
 func get_global_values() -> Dictionary:

--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_interpreter_factory.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_interpreter_factory.gd
@@ -13,3 +13,9 @@ static func create_interpreter() -> ESCInterpreter:
 	_interpreter = load("res://addons/escoria-core/game/core-scripts/esc/compiler/esc_interpreter.gd").new([], _interpreter.get_global_values())
 
 	return _interpreter
+
+
+static func reset_interpreter() -> void:
+	if is_instance_valid(_interpreter):
+		_interpreter.cleanup()
+		_interpreter = null

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -226,6 +226,7 @@ func _event_is_required(event_name: String) -> bool:
 
 # Called from escoria autoload to start a new game.
 func new_game():
+	escoria.event_manager.interrupt() # interrupt first because we're going to reset the interpreter
 	escoria.game_scene.escoria_show_ui()
 	escoria.globals_manager.clear()
 	escoria.interpreter_factory.reset_interpreter()
@@ -236,7 +237,6 @@ func new_game():
 			true,
 			true
 		)
-	escoria.event_manager.interrupt()
 	run_event_from_script(escoria.start_script, escoria.event_manager.EVENT_NEW_GAME)
 
 # Function called to quit the game.

--- a/addons/escoria-core/game/escoria.gd
+++ b/addons/escoria-core/game/escoria.gd
@@ -228,6 +228,7 @@ func _event_is_required(event_name: String) -> bool:
 func new_game():
 	escoria.game_scene.escoria_show_ui()
 	escoria.globals_manager.clear()
+	escoria.interpreter_factory.reset_interpreter()
 	escoria.main.clear_previous_scene()
 	escoria.creating_new_game = true
 	escoria.globals_manager.set_global(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to explicitly reset and clean up the interpreter and environment, improving resource management.

* **Refactor**
  * Adjusted the game reset process to ensure proper cleanup and interruption handling when starting a new game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->