### PR TITLE
fix: on room ready, reset the verb menu

### DIFF
--- a/addons/escoria-ui-simplemouse/game.gd
+++ b/addons/escoria-ui-simplemouse/game.gd
@@ -76,11 +76,11 @@ var targeted_node: Node
 func _ready():
 	hide_ui()
 	$ui/tooltip.connect("tooltip_size_updated", Callable(self, "update_tooltip_following_mouse_position"))
-
+	escoria.main.room_ready.connect(_on_room_ready)
 
 func _enter_tree():
 	initialize_esc_game()
-
+	
 	var room_selector_parent = $ui/HBoxContainer/VBoxContainer
 
 	if ESCProjectSettingsManager.get_setting(ESCProjectSettingsManager.ENABLE_ROOM_SELECTOR) \
@@ -481,6 +481,6 @@ func _on_event_done(_return_code: int, _event_name: String):
 		$mouse_layer/verbs_menu.set_by_name(VERB_WALK)
 
 
-
-func _on_MenuButton_pressed() -> void:
-	pause_game()
+func _on_room_ready():
+	$mouse_layer/verbs_menu.set_by_name(VERB_WALK)
+	$mouse_layer/verbs_menu.action_manually_changed = false

--- a/addons/escoria-ui-simplemouse/game.tscn
+++ b/addons/escoria-ui-simplemouse/game.tscn
@@ -8,7 +8,7 @@
 [ext_resource type="PackedScene" uid="uid://b3hru28v8y36i" path="res://addons/escoria-ui-simplemouse/tooltip/target_tooltip.tscn" id="6"]
 [ext_resource type="PackedScene" uid="uid://u8an5av5fuxx" path="res://addons/escoria-core/ui_library/menus/main_menu/main_menu.tscn" id="7"]
 [ext_resource type="PackedScene" uid="uid://gfjgmbcafyyt" path="res://addons/escoria-core/ui_library/menus/pause_menu/pause_menu.tscn" id="8"]
-[ext_resource type="FontFile" path="res://addons/escoria-ui-simplemouse/fonts/caslonantique.tres" id="8_c4xbd"]
+[ext_resource type="FontFile" uid="uid://7k2bd75ju4j7" path="res://addons/escoria-ui-simplemouse/fonts/caslonantique.tres" id="8_c4xbd"]
 [ext_resource type="Theme" uid="uid://cujvdn6gu1j74" path="res://addons/escoria-ui-simplemouse/theme.tres" id="9"]
 
 [node name="game" type="Node2D"]

--- a/game/rooms/room05/room05.tscn
+++ b/game/rooms/room05/room05.tscn
@@ -182,15 +182,15 @@ shape = SubResource("2")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="Hotspots/pipe"]
 libraries = {
-"": SubResource("AnimationLibrary_ck3xl")
+&"": SubResource("AnimationLibrary_ck3xl")
 }
 
 [node name="GPUParticles2D" type="GPUParticles2D" parent="Hotspots/pipe"]
 position = Vector2(593, 244)
 emitting = false
-process_material = SubResource("5")
 texture = ExtResource("9")
 lifetime = 1.5
+process_material = SubResource("5")
 
 [node name="ESCLocation" type="Marker2D" parent="Hotspots/pipe"]
 position = Vector2(618, 393)


### PR DESCRIPTION
Fixes https://github.com/godot-escoria/escoria-issues/issues/380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The verbs menu now automatically resets to the "walk" verb when a room is ready.

* **Other Changes**
  * Minor adjustments to resource identifiers and property ordering in scene files for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->