### PR TITLE
fix: type check in inc_global and dec_global

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/commands/dec_global.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/dec_global.gd
@@ -16,7 +16,7 @@ class_name DecGlobalCommand
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
 		1,
-		[TYPE_STRING, TYPE_INT],
+		[TYPE_STRING, TYPE_FLOAT],
 		[null, 1]
 	)
 
@@ -26,8 +26,8 @@ func validate(arguments: Array):
 	if not super.validate(arguments):
 		return false
 
-	if not escoria.globals_manager.get_global(arguments[0]) is int:
-		raise_error(self, "Invalid global. Global %s isn't an integer value." % arguments[0])
+	if not escoria.globals_manager.get_global(arguments[0]) is float:
+		raise_error(self, "Invalid global. Global %s isn't a float value." % arguments[0])
 		return false
 
 	return true

--- a/addons/escoria-core/game/core-scripts/esc/commands/inc_global.gd
+++ b/addons/escoria-core/game/core-scripts/esc/commands/inc_global.gd
@@ -16,7 +16,7 @@ class_name IncGlobalCommand
 func configure() -> ESCCommandArgumentDescriptor:
 	return ESCCommandArgumentDescriptor.new(
 		1,
-		[TYPE_STRING, TYPE_INT],
+		[TYPE_STRING, TYPE_FLOAT],
 		[null, 1]
 	)
 
@@ -29,8 +29,8 @@ func validate(arguments: Array):
 	if not escoria.globals_manager.has(arguments[0]):
 		raise_error(self, "Invalid global. Global %s does not exist." % arguments[0])
 		return false
-	if not escoria.globals_manager.get_global(arguments[0]) is int:
-		raise_error(self, "Invalid global. Global %s isn't an integer value." % arguments[0])
+	if not escoria.globals_manager.get_global(arguments[0]) is float:
+		raise_error(self, "Invalid global. Global %s isn't a float value." % arguments[0])
 		return false
 	return true
 


### PR DESCRIPTION
There was a bug where `inc_global` and `dec_global` commands expected an int value but the compiler produces floats, which crashes the game whenever you use one of them. I changed the type check at the command level. It seems to make more sense to be able to increment/decrement by a float since you can assign a float to an escoria global.
I've seen some other commands, e.g camera_push expect either float or int, but it looks like the compiler never actually produces an int.
```
esc_scanner.gd

func _number() -> void:
	while _is_digit(_peek()):
		_advance()

	# Fraction part?
	if _peek() == '.' and _is_digit(_peek_next()):
		_advance()

		while _is_digit(_peek()):
			_advance()

	_add_token(ESCTokenType.TokenType.NUMBER, _source.substr(_start, _current - _start).to_float())
```