### PR TITLE
Fix use_from_inventory_only use in action manager

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -661,9 +661,6 @@ func perform_inputevent_on_object(
 
 
 func _telekinetic_applies_to(event: ESCGrammarStmts.Event) -> bool:
-	if event == null:
-		return false
-
 	if event.get_flags_with_conditions().has("TK"):
 		var tk_flag_condition = event.get_flags_with_conditions().get("TK")
 

--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -592,18 +592,12 @@ func perform_inputevent_on_object(
 		# If clicked object needs a combination, and current target is set, then perform the combination.
 		if need_combine and current_target:
 			event_to_queue = _get_event_to_queue(current_action, current_tool, current_target)
-		# If clicked object needs a combination but can only be used from inventory, then we need to wait
-		# for the target.
-		elif obj.node.use_from_inventory_only \
-				and escoria.inventory_manager.inventory_has(obj.global_id) \
-				and need_combine:
-			current_tool = obj
-			set_action_input_state(ACTION_INPUT_STATE.AWAITING_TARGET_ITEM)
-			return
-		# If clicked object needs a combination and doesn't require to be in inventory,
-		# then we need to wait for the target.
+		# If clicked object needs a combination then we need to wait for the target.
 		elif need_combine:
 			set_action_input_state(ACTION_INPUT_STATE.AWAITING_TARGET_ITEM)
+			# If object is in inventory make it current tool.
+			if escoria.inventory_manager.inventory_has(obj.global_id):
+				current_tool = obj
 		# If clicked object doesn't need a combination, then we simply run the action.
 		else:
 			event_to_queue = _get_event_to_queue(current_action, obj)
@@ -667,6 +661,9 @@ func perform_inputevent_on_object(
 
 
 func _telekinetic_applies_to(event: ESCGrammarStmts.Event) -> bool:
+	if event == null:
+		return false
+
 	if event.get_flags_with_conditions().has("TK"):
 		var tk_flag_condition = event.get_flags_with_conditions().get("TK")
 

--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -280,20 +280,19 @@ func _get_event_to_queue(
 	if target.node is ESCItem \
 			and action in target.node.combine_when_selected_action_is_in:
 
-		# Check if object must be in inventory to be used
-		if target.node.use_from_inventory_only:
-			if escoria.inventory_manager.inventory_has(target.global_id):
-				# Player has item in inventory, we check the element to use on
-				if combine_with:
-					var do_combine = true
-					if combine_with.node is ESCItem \
-							and combine_with.node.use_from_inventory_only\
-							and not escoria.inventory_manager.inventory_has(
-								combine_with.global_id
-							):
-						do_combine = false
+		# Check if object is in inventory or is not required to be in inventory to be used
+		if escoria.inventory_manager.inventory_has(target.global_id) or not target.node.use_from_inventory_only:
+			# We check the element to use on
+			if combine_with:
+				var do_combine = true
+				if combine_with.node is ESCItem \
+						and combine_with.node.use_from_inventory_only\
+						and not escoria.inventory_manager.inventory_has(
+							combine_with.global_id
+						):
+					do_combine = false
 
-					if do_combine:
+				if do_combine:
 #						var target_event = "%s %s" % [
 #							action,
 #							combine_with.global_id
@@ -303,71 +302,71 @@ func _get_event_to_queue(
 #							target.global_id
 #						]
 
-						if _has_event_with_target(target.events, action, combine_with.global_id):
-						#if target.events.has(target_event):
-							#event_to_return = target.events[target_event]
-							event_to_return = target.events[action]
-						#elif combine_with.events.has(combine_with_event)\
-						elif _has_event_with_target(combine_with.events, action, target.global_id)\
-								and not combine_with.node.combine_is_one_way:
+					if _has_event_with_target(target.events, action, combine_with.global_id):
+					#if target.events.has(target_event):
+						#event_to_return = target.events[target_event]
+						event_to_return = target.events[action]
+					#elif combine_with.events.has(combine_with_event)\
+					elif _has_event_with_target(combine_with.events, action, target.global_id)\
+							and not combine_with.node.combine_is_one_way:
 
-							#event_to_return = combine_with.events[combine_with_event]
-							event_to_return = combine_with.events[action]
-						else:
-							# Check to see if there isn't a "fallback" action to
-							# run before we declare this a failure.
-							if escoria.action_default_script \
-								and escoria.action_default_script.events.has(action):
-
-								event_to_return = escoria.action_default_script.events[action]
-							else:
-								var errors = [
-									"Attempted to execute action '%s' between item %s and item %s" % [
-										action,
-										target.global_id,
-										combine_with.global_id
-									],
-									"Check that action ':%s %s' exists in the script of item '%s'" % [
-										action,
-										target.global_id,
-										combine_with.global_id
-									]
-								]
-
-								if combine_with.node.combine_is_one_way:
-									errors.append(
-										("Reason: %s's item interaction " + \
-										"is one-way.") % combine_with.global_id
-									)
-
-								escoria.logger.warn(
-									self,
-									"Invalid action: " + str(errors)
-								)
+						#event_to_return = combine_with.events[combine_with_event]
+						event_to_return = combine_with.events[action]
 					else:
-						escoria.logger.warn(
-							self,
-							"Invalid action on item: " +
-								(
-									"Trying to combine object %s with %s, "+
-									"but %s is not in inventory."
-								) % [
+						# Check to see if there isn't a "fallback" action to
+						# run before we declare this a failure.
+						if escoria.action_default_script \
+							and escoria.action_default_script.events.has(action):
+
+							event_to_return = escoria.action_default_script.events[action]
+						else:
+							var errors = [
+								"Attempted to execute action '%s' between item %s and item %s" % [
+									action,
 									target.global_id,
-									combine_with.global_id,
+									combine_with.global_id
+								],
+								"Check that action ':%s %s' exists in the script of item '%s'" % [
+									action,
+									target.global_id,
 									combine_with.global_id
 								]
-						)
-			else:
-				escoria.logger.warn(
-					self,
-					"Invalid action on item: " +
-					"Trying to run action '%s' on object %s, " %
-					[
-						action,
-						target.node.global_id
-					]
-					+ "but item must be in inventory."
-				)
+							]
+
+							if combine_with.node.combine_is_one_way:
+								errors.append(
+									("Reason: %s's item interaction " + \
+									"is one-way.") % combine_with.global_id
+								)
+
+							escoria.logger.warn(
+								self,
+								"Invalid action: " + str(errors)
+							)
+				else:
+					escoria.logger.warn(
+						self,
+						"Invalid action on item: " +
+							(
+								"Trying to combine object %s with %s, "+
+								"but %s is not in inventory."
+							) % [
+								target.global_id,
+								combine_with.global_id,
+								combine_with.global_id
+							]
+					)
+		else:
+			escoria.logger.warn(
+				self,
+				"Invalid action on item: " +
+				"Trying to run action '%s' on object %s, " %
+				[
+					action,
+					target.node.global_id
+				]
+				+ "but item must be in inventory."
+			)
 	else:
 		if _check_target_has_proper_action(target, action):
 #			##SAVEGAME

--- a/game/items/inventory/r5_wrench.tscn
+++ b/game/items/inventory/r5_wrench.tscn
@@ -20,7 +20,7 @@ combine_when_selected_action_is_in = PackedStringArray("use")
 hover_enabled = true
 hover_shader = ExtResource("2_r6a7q")
 default_action_inventory = "use"
-use_from_inventory_only = true
+use_from_inventory_only = false
 inventory_texture = ExtResource("1")
 inventory_texture_hovered = ExtResource("3_qlcni")
 


### PR DESCRIPTION
Make wrench usable in Room5 even if not marked with `use_from_inventory_only`.

Less lines are changed than it appears. Lines from 285 to 370 only lost a tab character.

Tested with simple_mouse and 9verbs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More flexible item interactions: items that don't require inventory can be used or combined directly in the scene.
  * Inventory items clicked in-scene can become the active tool for combining.

* **Bug Fixes**
  * Smarter action resolution and safer fallbacks when combination events are missing.
  * Clearer feedback when combinations are blocked (including one-way items).
  * Wrench now usable directly in the scene without taking it into inventory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->