### PR TITLE
fix(compiler): avoid crash when target is null

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/compiler/esc_grammar_stmts.gd
+++ b/addons/escoria-core/game/core-scripts/esc/compiler/esc_grammar_stmts.gd
@@ -125,6 +125,12 @@ class Event extends ESCGrammarStmt:
 
 
 	func get_target_name() -> String:
+		if _target == null:
+			escoria.logger.warn_message(
+				"esc_grammar_stmts.gd",
+				"Error getting target name, target is null."
+			)
+			return ""
 		return _target.get_value()
 
 


### PR DESCRIPTION
I don't know why in our game we are getting to the situation where the event has no target name, but it is happening. In any case, safety is never too much.

I'm not entirely comfortable returning an empty string, but since I can't return null, it's the best option I can think of.