### PR TITLE
changed dict key handling to avoid overriding events with many targets

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -422,11 +422,9 @@ func _check_target_has_proper_action(target: ESCObject, action: String) -> bool:
 # event_target
 func _has_event_with_target(events_dict: Dictionary, event_name: String, event_target: String):
 	var event = events_dict.get(event_name)
-
-	if event:
-		return event.get_target_name() == event_target
-
-	return false
+	if event == null:
+		return false
+	return true
 
 
 # Runs the specified event.

--- a/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_action_manager.gd
@@ -293,25 +293,21 @@ func _get_event_to_queue(
 					do_combine = false
 
 				if do_combine:
-#						var target_event = "%s %s" % [
-#							action,
-#							combine_with.global_id
-#						]
-#						var combine_with_event = "%s %s" % [
-#							action,
-#							target.global_id
-#						]
+					var action_name = action
+					if combine_with.global_id:
+						action_name += " " + combine_with.global_id
+					
+					var combine_name = action
+					if combine_with.global_id:
+						combine_name += " " + target.global_id
 
-					if _has_event_with_target(target.events, action, combine_with.global_id):
-					#if target.events.has(target_event):
-						#event_to_return = target.events[target_event]
-						event_to_return = target.events[action]
-					#elif combine_with.events.has(combine_with_event)\
-					elif _has_event_with_target(combine_with.events, action, target.global_id)\
+					if _has_event_with_target(target.events, action_name, combine_with.global_id):
+						event_to_return = target.events[action_name]
+
+					elif _has_event_with_target(combine_with.events, combine_name, target.global_id)\
 							and not combine_with.node.combine_is_one_way:
 
-						#event_to_return = combine_with.events[combine_with_event]
-						event_to_return = combine_with.events[action]
+						event_to_return = combine_with.events[combine_name]
 					else:
 						# Check to see if there isn't a "fallback" action to
 						# run before we declare this a failure.

--- a/addons/escoria-core/game/core-scripts/esc/esc_compiler.gd
+++ b/addons/escoria-core/game/core-scripts/esc/esc_compiler.gd
@@ -121,11 +121,11 @@ func _compiler_shim(source: String, filename: String = "", associated_global_id:
 
 	if not had_error:
 		for ps in parsed_statements:
-			script.events[ps.get_event_name()] = ps
-
+			var event_name = ps.get_event_name()
+			if ps.get_target() != null:
+				event_name += " " + ps.get_target_name()
+			script.events[event_name] = ps
 	return script
-	#if not had_error:
-	#	interpreter.interpret(parsed_statements)
 
 
 # Load an ESC file from a file resource. We also accept an optional global ID of

--- a/game/rooms/room05/esc/pipe.esc
+++ b/game/rooms/room05/esc/pipe.esc
@@ -18,3 +18,13 @@
 	say("player", "The leak's now fixed.")
 	r5_dialog_advance = 2
 	accept_input("ALL")
+
+:use "r5_pen"
+	if r5_dialog_advance == 2:
+		say("player", "I already fixed the water leak.")
+		stop
+
+	accept_input("SKIP")
+	say("player", "I don't see how I can fix the pipe with a pen.")
+	accept_input("ALL")
+	

--- a/game/rooms/room05/room05.tscn
+++ b/game/rooms/room05/room05.tscn
@@ -174,7 +174,7 @@ global_id = "r5_pipe"
 esc_script = "res://game/rooms/room05/esc/pipe.esc"
 tooltip_name = "pipe"
 default_action = "look"
-combine_when_selected_action_is_in = PackedStringArray()
+combine_when_selected_action_is_in = PackedStringArray("use")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Hotspots/pipe"]
 position = Vector2(618, 243)


### PR DESCRIPTION
Changed the key handling for the event dictionary.
Now instead of only using the event name it uses the target if it exists.

Adapted the action manager to the new keys.

Found the solution comparing how the event and target key was handled before the port to godot4.

Added an example with the pen.
Fixed use wrench with pipe in the process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Combining items now triggers the correct interaction on the intended target.
  * One‑way combinations are respected, preventing unintended reverse interactions.
  * Fallback to default actions remains consistent when no specific interaction is defined.

* **Refactor**
  * Interaction events are keyed with explicit targets for more precise action mapping.
  * Legacy generic lookups removed to reduce ambiguity and improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->