### PR TITLE
Hovered inventory texture default to inventory texture

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_item.gd
+++ b/addons/escoria-core/game/core-scripts/esc_item.gd
@@ -990,10 +990,7 @@ func _get_inventory_texture() -> Texture2D:
 
 func _get_inventory_texture_hovered() -> Texture2D:
 	if inventory_texture_hovered == null:
-		for c in get_children():
-			if c is TextureRect or c is Sprite2D:
-				return c.texture
-		return null
+		return _get_inventory_texture()
 	else:
 		return inventory_texture_hovered
 


### PR DESCRIPTION
I think that makes more sense defaulting to the inventory_texture when missing the inventory_texture_hovered.
Avoids having to always fill both variables with the same texture.
This affects only items that have a different texture for the inventory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hovered inventory icons now correctly fall back to the primary inventory texture when no explicit hover texture is set, ensuring consistent visuals.
  * Prevents mismatched or missing hover textures that could occur on some items.
  * Existing behavior is preserved when no textures are set; automatic texture detection still applies.
  * No changes required for existing content or integrations; improvements apply automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->