### PR TITLE
chore: adds command validation for interactive and state

### DIFF
--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -406,11 +406,11 @@ func _load_object(object_id: String, object_dictionary: Dictionary, room_id: Str
 			_set_active_if_exists.run([object_id, object_dictionary["active"]])
 
 		# Interactive
-		if object_dictionary.has("interactive") && _set_interactive.validate([object_id, object_dictionary["interactive"]]):
+		if object_dictionary.has("interactive") and _set_interactive.validate([object_id, object_dictionary["interactive"]]):
 			_set_interactive.run([object_id, object_dictionary["interactive"]])
 
 		# State
-		if object_dictionary.has("state") && _set_state.validate([object_id, object_dictionary["state"], true]):
+		if object_dictionary.has("state") and _set_state.validate([object_id, object_dictionary["state"], true]):
 			_set_state.run([object_id, object_dictionary["state"], true])
 
 		# Position

--- a/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
+++ b/addons/escoria-core/game/core-scripts/save_data/esc_save_manager.gd
@@ -406,11 +406,11 @@ func _load_object(object_id: String, object_dictionary: Dictionary, room_id: Str
 			_set_active_if_exists.run([object_id, object_dictionary["active"]])
 
 		# Interactive
-		if object_dictionary.has("interactive"):
+		if object_dictionary.has("interactive") && _set_interactive.validate([object_id, object_dictionary["interactive"]]):
 			_set_interactive.run([object_id, object_dictionary["interactive"]])
 
 		# State
-		if object_dictionary.has("state"):
+		if object_dictionary.has("state") && _set_state.validate([object_id, object_dictionary["state"], true]):
 			_set_state.run([object_id, object_dictionary["state"], true])
 
 		# Position


### PR DESCRIPTION
Items from a different room don't load and crashes.

Validating the commands doesn't fix the issue, in our case, but allows to continue and debug.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved save-game loading reliability by validating object interaction and state before applying changes, reducing errors and preventing crashes or inconsistent behavior from corrupted or incompatible save data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->