### PR TITLE
fix(Logger): avoid clash with new Logger native class

### DIFF
--- a/addons/escoria-core/game/core-scripts/esc_terrain.gd
+++ b/addons/escoria-core/game/core-scripts/esc_terrain.gd
@@ -6,7 +6,7 @@ class_name ESCTerrain
 
 
 # Logger class
-const Logger = preload("res://addons/escoria-core/tools/logging/esc_logger.gd")
+const EscLogger = preload("res://addons/escoria-core/tools/logging/esc_logger.gd")
 
 
 # Visualize scales or the lightmap for debugging purposes
@@ -88,7 +88,7 @@ var _lightmap_data
 var _texture_in_update = false
 
 # Logger instance
-@onready var logger = Logger.ESCLoggerFile.new()
+@onready var logger = EscLogger.ESCLoggerFile.new()
 
 # Set a reference to the active navigation polygon, register to Escoria
 # and update the texture

--- a/addons/escoria-core/game/esc_autoload.gd
+++ b/addons/escoria-core/game/esc_autoload.gd
@@ -35,7 +35,7 @@ const CAMERA_SCENE_PATH = "res://addons/escoria-core/game/scenes/camera_player/c
 
 
 # Logger class
-const Logger = preload("res://addons/escoria-core/tools/logging/esc_logger.gd")
+const EscLogger = preload("res://addons/escoria-core/tools/logging/esc_logger.gd")
 
 # Group for ESCItem's that can be collided with in a scene. Used for quick
 # retrieval of such nodes to easily change their attributes at the same time.
@@ -46,7 +46,7 @@ const GROUP_ITEM_TRIGGERS = "item_triggers"
 
 
 # Logger instance
-var logger = Logger.ESCLoggerFile.new()
+var logger = EscLogger.ESCLoggerFile.new()
 
 # ESC Compiler
 var esc_compiler = ESCCompiler.new()


### PR DESCRIPTION
Godot 4.5 introduced new native Logger class which clashed with Escoria Logger class.

Perhaps Escoria Logger should use the new class (https://godotengine.org/releases/4.5/#script-backtracing), but that is out of scope of this PR.